### PR TITLE
fix(asyncio): session.rollback called with default threadpool executor

### DIFF
--- a/fastapi_sqla.py
+++ b/fastapi_sqla.py
@@ -50,7 +50,7 @@ def open_session() -> Session:
         session.commit()
 
     except Exception:
-        logger.exception("commit failed. Rolling back")
+        logger.exception("commit failed, rolling back")
         session.rollback()
         raise
 

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -95,7 +95,7 @@ async def test_commit_error_returns_500(client, user_1):
         )
 
     assert res.status_code == 500
-    assert {"event": "commit failed. Rolling back", "log_level": "exception"} in caplog
+    assert {"event": "commit failed, rolling back", "log_level": "exception"} in caplog
 
 
 async def test_rollback_on_http_exception(client):


### PR DESCRIPTION
## Description

* IIUC `session.rollback` is a blocking call, it needs to be called in the default threadpool executor;

## Checklist

- [x] Follows [Commit Convention] and [Code Review guidelines] <!-- feat(lang): add German language - DIA-12345 -->
- [x] Relevant labels set 
- [x] Empty sections removed
- [x] Requested from and notified to a team


<!-- don't remove -->
[Commit Convention]: https://www.notion.so/godialogue/Commit-Convention-84fd9a4c149e48c998d760f1c9176df0
[Code Review guidelines]: https://www.notion.so/godialogue/Code-Review-c5f3fcd185ca49aca73ade497c398fe9
[Draft PR]: https://github.blog/2019-02-14-introducing-draft-pull-requests
