### PR TITLE
refactor: Simplify API

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,17 +47,17 @@ class Entity(Base):
     __tablename__ = "table-name-in-db"
 ```
 
-### Getting an sqla orm session
+### Getting an sqla session
 
 ```python
 from fastapi import APIRouter, Depends
-from fastapi_sqla import Session, with_session
+from fastapi_sqla import Session
 
 router = APIRouter()
 
 
 @router.get("/example")
-def example(session: Session = Depends(with_session)):
+def example(session: Session = Depends()):
     return session.execute("SELECT now()").scalar()
 ```
 
@@ -71,7 +71,6 @@ from fastapi_sqla import (
     PaginatedResult,
     Session,
     with_pagination,
-    with_session,
 )
 from pydantic import BaseModel
 
@@ -89,7 +88,7 @@ class User(BaseModel):
 
 @router.get("/users", response_model=Paginated[User])
 def all_users(
-    session: Session = Depends(with_session),
+    session: Session = Depends(),
     paginated_result: PaginatedResult = Depends(with_pagination),
 ):
     query = session.query(UserEntity)
@@ -116,7 +115,6 @@ from fastapi_sqla import (
     PaginatedResult,
     Pagination,
     Session,
-    with_session,
 )
 from pydantic import BaseModel
 from sqlalchemy import func
@@ -147,7 +145,7 @@ with_custom_pagination = Pagination(
 
 @router.get("/users", response_model=Paginated[User])
 def all_users(
-    session: Session = Depends(with_session),
+    session: Session = Depends(),
     paginated_result: PaginatedResult = Depends(with_custom_pagination),
 ):
     query = session.query(UserEntity)

--- a/README.md
+++ b/README.md
@@ -65,13 +65,7 @@ def example(session: Session = Depends()):
 
 ```python
 from fastapi import APIRouter, Depends
-from fastapi_sqla import (
-    Base,
-    Paginated,
-    PaginatedResult,
-    Session,
-    with_pagination,
-)
+from fastapi_sqla import Base, Page, Paginate, Session
 from pydantic import BaseModel
 
 router = APIRouter()
@@ -86,13 +80,10 @@ class User(BaseModel):
     name: str
 
 
-@router.get("/users", response_model=Paginated[User])
-def all_users(
-    session: Session = Depends(),
-    paginated_result: PaginatedResult = Depends(with_pagination),
-):
+@router.get("/users", response_model=Page[User])
+def all_users(session: Session = Depends(), paginate: Paginate = Depends()):
     query = session.query(UserEntity)
-    return paginated_result(query)
+    return paginate(query)
 ```
 
 By default:
@@ -109,13 +100,7 @@ To customize pagination, create a dependency using `fastapi_sqla.Pagination`
 
 ```python
 from fastapi import APIRouter, Depends
-from fastapi_sqla import (
-    Base,
-    Paginated,
-    PaginatedResult,
-    Pagination,
-    Session,
-)
+from fastapi_sqla import Base, Page, Pagination, Session
 from pydantic import BaseModel
 from sqlalchemy import func
 from sqlalchemy.orm import Query
@@ -136,20 +121,20 @@ def query_count(session: Session, query: Query):
     return query.statement.with_only_columns([func.count()]).scalar()
 
 
-with_custom_pagination = Pagination(
+Paginate = Pagination(
     min_page_size=5,
     max_page_size=500,
     query_count=query_count,
 )
 
 
-@router.get("/users", response_model=Paginated[User])
+@router.get("/users", response_model=Page[User])
 def all_users(
     session: Session = Depends(),
-    paginated_result: PaginatedResult = Depends(with_custom_pagination),
+    paginate: Paginate = Depends(),
 ):
     query = session.query(UserEntity)
-    return paginated_result(query)
+    return paginate(query)
 ```
 
 ## Pytest fixtures

--- a/fastapi_sqla/__init__.py
+++ b/fastapi_sqla/__init__.py
@@ -12,7 +12,8 @@ from pydantic.generics import GenericModel
 from sqlalchemy import engine_from_config
 from sqlalchemy.ext.declarative import DeferredReflection, declarative_base
 from sqlalchemy.orm import Query as DbQuery
-from sqlalchemy.orm.session import Session as SqlaSession, sessionmaker
+from sqlalchemy.orm.session import Session as SqlaSession
+from sqlalchemy.orm.session import sessionmaker
 
 __all__ = ["Base", "Page", "Paginate", "Session", "open_session", "setup"]
 

--- a/fastapi_sqla/__init__.py
+++ b/fastapi_sqla/__init__.py
@@ -14,7 +14,7 @@ from sqlalchemy.ext.declarative import DeferredReflection, declarative_base
 from sqlalchemy.orm import Query as DbQuery
 from sqlalchemy.orm.session import Session as SqlaSession, sessionmaker
 
-__all__ = ["Base", "Page", "Paginate", "Session", "setup"]
+__all__ = ["Base", "Page", "Paginate", "Session", "open_session", "setup"]
 
 logger = structlog.get_logger(__name__)
 

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -37,7 +37,7 @@ def User():
 
 @fixture
 def app(User):
-    from fastapi_sqla import setup, with_session
+    from fastapi_sqla import Session, setup
 
     app = FastAPI()
     setup(app)
@@ -48,7 +48,7 @@ def app(User):
         last_name: str
 
     @app.post("/users")
-    def create_user(user: UserIn, session=Depends(with_session)):
+    def create_user(user: UserIn, session: Session = Depends()):
         session.add(User(**user.dict()))
         return {}
 

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -113,6 +113,7 @@ def test_Pagination_with_custom_count(
 @fixture
 def app(user_cls, note_cls):
     from sqlalchemy.orm import joinedload
+
     from fastapi_sqla import Page, Paginate, Session, setup
 
     app = FastAPI()

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -113,7 +113,7 @@ def test_Pagination_with_custom_count(
 def app(user_cls, note_cls):
     from sqlalchemy.orm import joinedload
 
-    from fastapi_sqla import Paginated, Session, setup, with_pagination, with_session
+    from fastapi_sqla import Paginated, Session, setup, with_pagination
 
     app = FastAPI()
     setup(app)
@@ -129,7 +129,7 @@ def app(user_cls, note_cls):
 
     @app.get("/users")
     def all_users(
-        session: Session = Depends(with_session),
+        session: Session = Depends(),
         paginated_result=Depends(with_pagination),
         reponse_model=Paginated[User],
     ):


### PR DESCRIPTION
## Description

* Simplify getting an SQLAlchemy session & pagination utilities (inspired from https://github.com/uriyyo/fastapi-pagination);
* Document getting an SQLAlchemy session using FastAPI dependency injection or using the context manager;

## BREAKING CHANGES

* Removed `with_session`: directly use `fastapi_sqla.Session` instead;
* Renamed:
      - `with_pagination` to `Paginate`
      - `Paginated` to `Page`
* Removed `PaginatedResult` as only `Paginate` is sufficient;
