### PR TITLE
fix: fixtures must not require asyncpg

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,7 @@ workflows:
           matrix:
             parameters:
               sqlalchemy_version: ["1.3", "1.4"]
+              asyncpg: ["asyncpg", "noasyncpg"]
       - release/release:
           name: release
           requires:
@@ -49,7 +50,13 @@ workflows:
 jobs:
 
   test:
+    environment:
+      CACHE_VERSION: "2021-05-02T10:18:17.640582"
     parameters:
+      asyncpg:
+        type: enum
+        enum: ["asyncpg", "noasyncpg"]
+        description: To run tests with and without asyncpg installed.
       sqlalchemy_version:
         type: enum
         enum: ["1.4", "1.3"]
@@ -61,7 +68,7 @@ jobs:
       - base/setup
       - python/setup
       - utils/with_cache:
-          key: 'sqlalchemy<<parameters.sqlalchemy_version>>-{{ checksum "pyproject.toml" }}-{{ checksum "poetry.lock" }}'
+          key: 'sqlalchemy<<parameters.sqlalchemy_version>>-<<parameters.asyncpg>>-{{ checksum "pyproject.toml" }}-{{ checksum "poetry.lock" }}'
           namespace: tox
           path: ~/project/.tox
           steps:
@@ -70,11 +77,11 @@ jobs:
                 command: |
                   poetry run pip install -U tox
             - run:
-                name: "run tox using sqlalchemy <<parameters.sqlalchemy_version>>.*"
+                name: "run tox using sqlalchemy <<parameters.sqlalchemy_version>>.* and -<<parameters.asyncpg>>"
                 command: |
                   poetry run tox -e sqlalchemy<<parameters.sqlalchemy_version>>
       - utils/send_coverage_to_codecov:
-          codecov_flag: sqlalchemy<<parameters.sqlalchemy_version>>
+          codecov_flag: sqlalchemy<<parameters.sqlalchemy_version>>-<<parameters.asyncpg>>
 
   publish:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,7 @@ jobs:
             - run:
                 name: "run tox using sqlalchemy <<parameters.sqlalchemy_version>>.* and -<<parameters.asyncpg>>"
                 command: |
-                  poetry run tox -e sqlalchemy<<parameters.sqlalchemy_version>>-<<parameters.asyncpg>>"
+                  poetry run tox -e sqlalchemy<<parameters.sqlalchemy_version>>-<<parameters.asyncpg>>
       - utils/send_coverage_to_codecov:
           codecov_flag: sqlalchemy<<parameters.sqlalchemy_version>>-<<parameters.asyncpg>>
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,6 +80,8 @@ jobs:
                 name: "run tox using sqlalchemy <<parameters.sqlalchemy_version>>.* and -<<parameters.asyncpg>>"
                 command: |
                   poetry run tox -e sqlalchemy<<parameters.sqlalchemy_version>>-<<parameters.asyncpg>>
+      - store_test_results:
+          path: test-reports
       - utils/send_coverage_to_codecov:
           codecov_flag: sqlalchemy<<parameters.sqlalchemy_version>>-<<parameters.asyncpg>>
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,15 +53,15 @@ jobs:
     environment:
       CACHE_VERSION: "2021-05-02T10:18:17.640582"
     parameters:
-      asyncpg:
-        type: enum
-        enum: ["asyncpg", "noasyncpg"]
-        description: To run tests with and without asyncpg installed.
       sqlalchemy_version:
         type: enum
         enum: ["1.4", "1.3"]
         description: |
           Specify which version of sqlalchemy to run the tests against
+      asyncpg:
+        type: enum
+        enum: ["asyncpg", "noasyncpg"]
+        description: To run tests with and without asyncpg installed.
     executor: python-postgres
     working_directory: ~/project/.
     steps:
@@ -79,7 +79,7 @@ jobs:
             - run:
                 name: "run tox using sqlalchemy <<parameters.sqlalchemy_version>>.* and -<<parameters.asyncpg>>"
                 command: |
-                  poetry run tox -e sqlalchemy<<parameters.sqlalchemy_version>>
+                  poetry run tox -e sqlalchemy<<parameters.sqlalchemy_version>>-<<parameters.asyncpg>>"
       - utils/send_coverage_to_codecov:
           codecov_flag: sqlalchemy<<parameters.sqlalchemy_version>>-<<parameters.asyncpg>>
 

--- a/fastapi_sqla/_pytest_plugin.py
+++ b/fastapi_sqla/_pytest_plugin.py
@@ -1,5 +1,6 @@
 import os
 from unittest.mock import patch
+from urllib.parse import urlsplit, urlunsplit
 
 from alembic import command
 from alembic.config import Config
@@ -103,16 +104,21 @@ def session(sqla_transaction, sqla_connection):
     session.close()
 
 
+def format_async_async_sqlalchemy_url(url):
+    scheme, location, path, query, fragment = urlsplit(url)
+    return urlunsplit([f"{scheme}+asyncpg", location, path, query, fragment])
+
+
+@fixture(scope="session")
+def async_sqlalchemy_url(db_url):
+    """Default async db url.
+
+    It is the same as `db_url` with `postgresql+asynpg://` as scheme.
+    """
+    return format_async_async_sqlalchemy_url(db_url)
+
+
 if asyncio_support:
-
-    @fixture(scope="session")
-    def async_sqlalchemy_url(db_url):
-        """Default async db url.
-
-        It is the same as `db_url` with `postgresql+asynpg://` as scheme.
-        """
-        scheme, parts = db_url.split(":")
-        return f"{scheme}+asyncpg:{parts}"
 
     @fixture
     async def async_engine(async_sqlalchemy_url):

--- a/fastapi_sqla/_pytest_plugin.py
+++ b/fastapi_sqla/_pytest_plugin.py
@@ -8,6 +8,7 @@ from sqlalchemy import create_engine, text
 
 try:
     from sqlalchemy.ext.asyncio import create_async_engine
+    import asyncpg  # noqa
 
     asyncio_support = True
 except ImportError:

--- a/fastapi_sqla/_pytest_plugin.py
+++ b/fastapi_sqla/_pytest_plugin.py
@@ -113,7 +113,7 @@ def format_async_async_sqlalchemy_url(url):
 def async_sqlalchemy_url(db_url):
     """Default async db url.
 
-    It is the same as `db_url` with `postgresql+asynpg://` as scheme.
+    It is the same as `db_url` with `postgresql+asyncpg://` as scheme.
     """
     return format_async_async_sqlalchemy_url(db_url)
 

--- a/fastapi_sqla/_pytest_plugin.py
+++ b/fastapi_sqla/_pytest_plugin.py
@@ -7,8 +7,8 @@ from pytest import fixture
 from sqlalchemy import create_engine, text
 
 try:
-    from sqlalchemy.ext.asyncio import create_async_engine
     import asyncpg  # noqa
+    from sqlalchemy.ext.asyncio import create_async_engine
 
     asyncio_support = True
 except ImportError:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,6 @@ tox = { version = "^3.23.0", optional = true}
 tests = [
     "alembic",
     "asgi_lifespan",
-    "asyncpg",
     "black",
     "Faker",
     "httpx",
@@ -97,15 +96,15 @@ fastapi-sqla = "fastapi_sqla._pytest_plugin"
 legacy_tox_ini = """
 [tox]
 isolated_build = True
-envlist = sqlalchemy{1.3,1.4}
+envlist = sqlalchemy{ 1.3, 1.4 }-{ asyncpg, noasyncpg }
 
 [testenv]
 passenv = CI
 deps =
     sqlalchemy1.3: sqlalchemy<1.4
     sqlalchemy1.4: sqlalchemy>=1.4,<2
+    asyncpg: asyncpg
 extras =
-    asyncpg
     tests
 commands = pytest -vv --cov={envsitepackagesdir}/fastapi_sqla --cov-report xml --cov-report html --junitxml=test-reports/pytest/junit.xml
 """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,7 +43,6 @@ def environ(db_url, sqla_version_tuple, async_sqlalchemy_url):
     values = {"sqlalchemy_url": db_url, "PYTHONASYNCIODEBUG": "1"}
 
     if sqla_version_tuple >= (1, 4, 0) and is_asyncpg_installed():
-        scheme, parts = db_url.split(":")
         values["async_sqlalchemy_url"] = async_sqlalchemy_url
 
     with patch.dict("os.environ", values=values, clear=True):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,12 +39,12 @@ def is_asyncpg_installed():
 
 
 @fixture(scope="session", autouse=True)
-def environ(db_url, sqla_version_tuple):
+def environ(db_url, sqla_version_tuple, async_sqlalchemy_url):
     values = {"sqlalchemy_url": db_url, "PYTHONASYNCIODEBUG": "1"}
 
     if sqla_version_tuple >= (1, 4, 0) and is_asyncpg_installed():
         scheme, parts = db_url.split(":")
-        values["async_sqlalchemy_url"] = f"{scheme}+asyncpg:{parts}"
+        values["async_sqlalchemy_url"] = async_sqlalchemy_url
 
     with patch.dict("os.environ", values=values, clear=True):
         yield values

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -89,7 +89,7 @@ def check_sqlalchemy_version(request, sqla_version_tuple):
 
 @fixture(autouse=True)
 def check_asyncpg(request):
-    "Skip test marked with mark.asyncpg if asyncpg is not installed."
+    "Skip test marked with mark.require_asyncpg if asyncpg is not installed."
     marker = request.node.get_closest_marker("require_asyncpg")
     if marker and not is_asyncpg_installed():
         skip("This test requires asyncpg. Skipping as asyncpg is not installed.")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,9 @@ def pytest_configure(config):
             "sqlalchemy version"
         ),
     )
+    config.addinivalue_line(
+        "markers", "require_asyncpg: skip test if asyncpg is not installed"
+    )
 
 
 @fixture(scope="session")
@@ -26,11 +29,20 @@ def sqla_version_tuple():
     return tuple(int(i) for i in __version__.split("."))
 
 
+def is_asyncpg_installed():
+    try:
+        import asyncpg  # noqa
+    except ImportError:
+        return False
+    else:
+        return True
+
+
 @fixture(scope="session", autouse=True)
 def environ(db_url, sqla_version_tuple):
     values = {"sqlalchemy_url": db_url, "PYTHONASYNCIODEBUG": "1"}
 
-    if sqla_version_tuple >= (1, 4, 0):
+    if sqla_version_tuple >= (1, 4, 0) and is_asyncpg_installed():
         scheme, parts = db_url.split(":")
         values["async_sqlalchemy_url"] = f"{scheme}+asyncpg:{parts}"
 
@@ -74,6 +86,15 @@ def check_sqlalchemy_version(request, sqla_version_tuple):
             skip(
                 f"Marked to run against sqlalchemy=^{expected}.0, but got {__version__}"
             )
+
+
+@fixture(autouse=True)
+def check_asyncpg(request):
+    "Skip test marked with mark.asyncpg if asyncpg is not installed."
+    marker = request.node.get_closest_marker("require_asyncpg")
+
+    if marker and not is_asyncpg_installed():
+        skip("This test requires asyncpg. Skipping as asyncpg is not installed.")
 
 
 @fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -92,7 +92,6 @@ def check_sqlalchemy_version(request, sqla_version_tuple):
 def check_asyncpg(request):
     "Skip test marked with mark.asyncpg if asyncpg is not installed."
     marker = request.node.get_closest_marker("require_asyncpg")
-
     if marker and not is_asyncpg_installed():
         skip("This test requires asyncpg. Skipping as asyncpg is not installed.")
 

--- a/tests/test_asyncio_support.py
+++ b/tests/test_asyncio_support.py
@@ -1,7 +1,7 @@
 from pytest import fixture, mark
 from sqlalchemy import text
 
-pytestmark = [mark.asyncio, mark.sqlalchemy("1.4")]
+pytestmark = [mark.asyncio, mark.sqlalchemy("1.4"), mark.require_asyncpg]
 
 
 @fixture(autouse=True)

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -95,6 +95,7 @@ async def test_session_dependency(client, faker, session):
     assert row == (userid, first_name, last_name)
 
 
+@mark.require_asyncpg
 @mark.sqlalchemy("1.4")
 async def test_async_session_dependency(client, faker, async_session):
     userid = faker.unique.random_int()

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -222,6 +222,7 @@ async def client(app):
             yield client
 
 
+@mark.require_asyncpg
 @mark.asyncio
 @mark.parametrize(
     "offset,items_number,path",

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -128,3 +128,16 @@ def test_sqla_modules_fixture_raises_exception_when_not_overriden(testdir, conft
     result = testdir.runpytest()
     result.assert_outcomes(errors=1)
     result.stdout.fnmatch_lines(["*sqla_modules fixture is not defined*"])
+
+
+@mark.parametrize(
+    "url,expected",
+    [
+        ("postgresql://localhost/db", "postgresql+asyncpg://localhost/db"),
+        ("postgresql://u:p@localhost/db", "postgresql+asyncpg://u:p@localhost/db"),
+    ],
+)
+def test_format_async_sqlalchemy_url(monkeypatch, conftest, testdir, url, expected):
+    from fastapi_sqla._pytest_plugin import format_async_async_sqlalchemy_url
+
+    assert format_async_async_sqlalchemy_url(url) == expected

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -41,6 +41,7 @@ def test_session_fixture_does_not_write_in_db(session, singer_cls, engine):
         assert connection.execute(text("select count(*) from singer")).scalar() == 0
 
 
+@mark.require_asyncpg
 @mark.asyncio
 @mark.sqlalchemy("1.4")
 async def test_async_session_fixture_does_not_write_in_db(
@@ -66,6 +67,7 @@ def test_all_opened_sessions_are_within_the_same_transaction(
     assert other_session.query(singer_cls).get(1)
 
 
+@mark.require_asyncpg
 @mark.asyncio
 @mark.sqlalchemy("1.4")
 async def test_all_opened_async_sessions_are_within_the_same_transaction(


### PR DESCRIPTION
## Description

As described in #34, `asynpg` is required when using pytest fixtures.

- [x] update tox configuration to allow testing with or without `asyncpg`
- [x] fix so that if `asyncpg` is not installed, it doesn't fail;
- [x] fix `async_sqlalchemy_url` to allow any URL, it currently fails if more than one colon is in the URL;