### PR TITLE
feat: use query_count as a FastAPI dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,4 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+test-reports/

--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ You can customize:
 - Minimum and maximum number of items per pages;
 - How the total number of items in the collection is queried;
 
-To customize pagination, create a dependency using `fastapi_sqla.Pagination`.
+To customize pagination, create a dependency using `fastapi_sqla.Pagination`:
 
 ```python
 from fastapi import APIRouter, Depends

--- a/README.md
+++ b/README.md
@@ -227,14 +227,13 @@ You can customize:
 - Minimum and maximum number of items per pages;
 - How the total number of items in the collection is queried;
 
-To customize pagination, create a dependency using `fastapi_sqla.Pagination`
+To customize pagination, create a dependency using `fastapi_sqla.Pagination`.
 
 ```python
 from fastapi import APIRouter, Depends
 from fastapi_sqla import Base, Page, Pagination, Session
 from pydantic import BaseModel
 from sqlalchemy import func, select
-from sqlalchemy.sql import Select
 
 router = APIRouter()
 
@@ -248,7 +247,7 @@ class UserModel(BaseModel):
     name: str
 
 
-def query_count(session: Session, query: Select) -> int:
+def query_count(session: Session = Depends()) -> int:
     return session.execute(select(func.count()).select_from(User)).scalar()
 
 

--- a/fastapi_sqla/__init__.py
+++ b/fastapi_sqla/__init__.py
@@ -264,9 +264,9 @@ def _paginate(
     )
 
 
-DefaultDependancy = Callable[[Session, int, int], PaginateSignature]
+DefaultDependency = Callable[[Session, int, int], PaginateSignature]
 WithQueryCountDependency = Callable[[Session, int, int, int], PaginateSignature]
-PaginationResult = Union[DefaultDependancy, WithQueryCountDependency]
+PaginationResult = Union[DefaultDependency, WithQueryCountDependency]
 
 
 def Pagination(

--- a/fastapi_sqla/__init__.py
+++ b/fastapi_sqla/__init__.py
@@ -273,7 +273,7 @@ def Pagination(
     max_page_size: int = 100,
     query_count: QueryCountDependency = None,
 ) -> PaginateDependency:
-    def dependency(
+    def default_dependency(
         session: Session = Depends(),
         offset: int = Query(0, ge=0),
         limit: int = Query(min_page_size, ge=1, le=max_page_size),
@@ -302,7 +302,7 @@ def Pagination(
     if query_count:
         return with_query_count_dependency
     else:
-        return dependency
+        return default_dependency
 
 
 Paginate: PaginateDependency = Pagination()

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,6 @@ xfail_strict = true
 addopts =
     -p no:fastapi-sqla
     --strict-markers
-    --cov fastapi_sqla
     --cov-config setup.cfg
     --cov-report term
     --cov-report term-missing

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,6 +5,7 @@ xfail_strict = true
 addopts =
     -p no:fastapi-sqla
     --strict-markers
+    --cov fastapi_sqla
     --cov-config setup.cfg
     --cov-report term
     --cov-report term-missing


### PR DESCRIPTION
## Description

* Custom pagination relying on a callable rather than a FastAPI dependency is sub-optimal;
* This PR introduces a breaking change to change that callable to be a dependency;