### PR TITLE
feat: fail at startup when connections info is incorrect - DIA-38713

### DIFF
--- a/fastapi_sqla/__init__.py
+++ b/fastapi_sqla/__init__.py
@@ -66,6 +66,17 @@ def startup():
     Base.metadata.bind = engine
     Base.prepare(engine)
     _Session.configure(bind=engine)
+
+    # Fail early:
+    try:
+        with open_session() as session:
+            session.execute("select 'OK'")
+    except Exception:
+        logger.critical(
+            "Fail querying db: is sqlalchemy_url envvar correctly configured?"
+        )
+        raise
+
     logger.info("startup", engine=engine)
 
 

--- a/fastapi_sqla/__init__.py
+++ b/fastapi_sqla/__init__.py
@@ -16,7 +16,7 @@ from sqlalchemy.ext.declarative import DeferredReflection
 from sqlalchemy.orm import Query as LegacyQuery
 from sqlalchemy.orm.session import Session as SqlaSession
 from sqlalchemy.orm.session import sessionmaker
-from sqlalchemy.sql import Select, func, select
+from sqlalchemy.sql import Select, func, select, text
 
 try:
     from sqlalchemy.orm import declarative_base
@@ -66,6 +66,17 @@ def startup():
     Base.metadata.bind = engine
     Base.prepare(engine)
     _Session.configure(bind=engine)
+
+    # Fail early:
+    try:
+        with open_session() as session:
+            session.execute(select(text("'OK'")))
+    except Exception:
+        logger.critical(
+            "Fail querying db: is sqlalchemy_url envvar correctly configured?"
+        )
+        raise
+
     logger.info("startup", engine=engine)
 
 

--- a/fastapi_sqla/__init__.py
+++ b/fastapi_sqla/__init__.py
@@ -16,7 +16,7 @@ from sqlalchemy.ext.declarative import DeferredReflection
 from sqlalchemy.orm import Query as LegacyQuery
 from sqlalchemy.orm.session import Session as SqlaSession
 from sqlalchemy.orm.session import sessionmaker
-from sqlalchemy.sql import Select, func, select, text
+from sqlalchemy.sql import Select, func, select
 
 try:
     from sqlalchemy.orm import declarative_base
@@ -66,17 +66,6 @@ def startup():
     Base.metadata.bind = engine
     Base.prepare(engine)
     _Session.configure(bind=engine)
-
-    # Fail early:
-    try:
-        with open_session() as session:
-            session.execute(text("select 'ok'"))
-    except Exception:
-        logger.critical(
-            "Fail querying db: is sqlalchemy_url envvar correctly configured?"
-        )
-        raise
-
     logger.info("startup", engine=engine)
 
 

--- a/fastapi_sqla/__init__.py
+++ b/fastapi_sqla/__init__.py
@@ -70,7 +70,7 @@ def startup():
     # Fail early:
     try:
         with open_session() as session:
-            session.execute(select(text("'OK'")))
+            session.execute(text("select 'ok'"))
     except Exception:
         logger.critical(
             "Fail querying db: is sqlalchemy_url envvar correctly configured?"

--- a/fastapi_sqla/_pytest_plugin.py
+++ b/fastapi_sqla/_pytest_plugin.py
@@ -135,13 +135,19 @@ if asyncio_support:
             await connection.rollback()
 
     @fixture(autouse=True)
-    async def patch_async_sessionmaker(async_sqlalchemy_url, async_sqla_connection):
+    async def patch_async_sessionmaker(
+        async_sqlalchemy_url, async_sqla_connection, request
+    ):
         """So that all async DB operations are never written to db for real."""
-        with patch(
-            "fastapi_sqla.asyncio_support.create_async_engine"
-        ) as create_async_engine:
-            create_async_engine.return_value = async_sqla_connection
-            yield create_async_engine
+        if "dont_patch_engine_from_config" in request.keywords:
+            yield
+
+        else:
+            with patch(
+                "fastapi_sqla.asyncio_support.create_async_engine"
+            ) as create_async_engine:
+                create_async_engine.return_value = async_sqla_connection
+                yield create_async_engine
 
     @fixture
     async def async_session(async_sqla_connection):

--- a/fastapi_sqla/_pytest_plugin.py
+++ b/fastapi_sqla/_pytest_plugin.py
@@ -78,7 +78,7 @@ def sqla_reflection(sqla_modules, sqla_connection, db_url):
 @fixture(autouse=True)
 def engine_from_config(request, db_url, sqla_connection, sqla_transaction):
     """So that all DB operations are never written to db for real."""
-    if "dont_patch_engine" in request.keywords:
+    if "dont_patch_engines" in request.keywords:
         yield
 
     else:
@@ -139,7 +139,7 @@ if asyncio_support:
         async_sqlalchemy_url, async_sqla_connection, request
     ):
         """So that all async DB operations are never written to db for real."""
-        if "dont_patch_engine" in request.keywords:
+        if "dont_patch_engines" in request.keywords:
             yield
 
         else:

--- a/fastapi_sqla/_pytest_plugin.py
+++ b/fastapi_sqla/_pytest_plugin.py
@@ -78,7 +78,7 @@ def sqla_reflection(sqla_modules, sqla_connection, db_url):
 @fixture(autouse=True)
 def engine_from_config(request, db_url, sqla_connection, sqla_transaction):
     """So that all DB operations are never written to db for real."""
-    if "dont_patch_engine_from_config" in request.keywords:
+    if "dont_patch_engine" in request.keywords:
         yield
 
     else:
@@ -139,7 +139,7 @@ if asyncio_support:
         async_sqlalchemy_url, async_sqla_connection, request
     ):
         """So that all async DB operations are never written to db for real."""
-        if "dont_patch_engine_from_config" in request.keywords:
+        if "dont_patch_engine" in request.keywords:
             yield
 
         else:

--- a/fastapi_sqla/asyncio_support.py
+++ b/fastapi_sqla/asyncio_support.py
@@ -3,7 +3,7 @@ from contextlib import asynccontextmanager
 
 import structlog
 from fastapi import Request
-from sqlalchemy import select, text
+from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession as SqlaAsyncSession
 from sqlalchemy.ext.asyncio import create_async_engine
 from sqlalchemy.orm.session import sessionmaker
@@ -21,7 +21,7 @@ async def startup():
     # Fail early:
     try:
         async with open_session() as session:
-            await session.execute(select(text("'OK'")))
+            await session.execute(text("select 'ok'"))
     except Exception:
         logger.critical(
             "Fail querying db: is async_sqlalchemy_url envvar correctly configured?"

--- a/fastapi_sqla/asyncio_support.py
+++ b/fastapi_sqla/asyncio_support.py
@@ -3,6 +3,7 @@ from contextlib import asynccontextmanager
 
 import structlog
 from fastapi import Request
+from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession as SqlaAsyncSession
 from sqlalchemy.ext.asyncio import create_async_engine
 from sqlalchemy.orm.session import sessionmaker
@@ -12,10 +13,20 @@ _ASYNC_SESSION_KEY = "fastapi_sqla_async_session"
 _AsyncSession = sessionmaker(class_=SqlaAsyncSession)
 
 
-def startup():
+async def startup():
     async_sqlalchemy_url = os.environ["async_sqlalchemy_url"]
-    async_engine = create_async_engine(async_sqlalchemy_url)
-    _AsyncSession.configure(bind=async_engine, expire_on_commit=False)
+    engine = create_async_engine(async_sqlalchemy_url)
+    _AsyncSession.configure(bind=engine, expire_on_commit=False)
+
+    # Fail early:
+    try:
+        async with open_session() as session:
+            await session.execute(select(text("'OK'")))
+    except Exception:
+        logger.critical(
+            "Fail querying db: is async_sqlalchemy_url envvar correctly configured?"
+        )
+        raise
 
 
 class AsyncSession(SqlaAsyncSession):

--- a/fastapi_sqla/asyncio_support.py
+++ b/fastapi_sqla/asyncio_support.py
@@ -28,6 +28,8 @@ async def startup():
         )
         raise
 
+    logger.info("startup", async_engine=engine)
+
 
 class AsyncSession(SqlaAsyncSession):
     def __new__(cls, request: Request) -> SqlaAsyncSession:

--- a/tests/test_asyncio_support.py
+++ b/tests/test_asyncio_support.py
@@ -5,17 +5,17 @@ pytestmark = [mark.asyncio, mark.sqlalchemy("1.4"), mark.require_asyncpg]
 
 
 @fixture(autouse=True)
-def setup(environ):
+async def setup(environ):
     from fastapi_sqla.asyncio_support import startup
 
-    startup()
+    await startup()
     yield
 
 
 async def test_startup_configure_async_session():
     from fastapi_sqla.asyncio_support import _AsyncSession, startup
 
-    startup()
+    await startup()
 
     async with _AsyncSession() as session:
         res = await session.execute(text("SELECT 123"))

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -16,7 +16,7 @@ def case_sensitive_environ(environ, request):
         yield values
 
 
-@mark.dont_patch_engine_from_config
+@mark.dont_patch_engine
 def test_startup(case_sensitive_environ):
     from fastapi_sqla import _Session, startup
 
@@ -50,7 +50,7 @@ async def test_fastapi_integration():
     assert res.json() == 1
 
 
-@mark.dont_patch_engine_from_config
+@mark.dont_patch_engine
 def test_startup_fail_on_bad_sqlalchemy_url(monkeypatch):
     from fastapi_sqla import startup
 
@@ -61,7 +61,7 @@ def test_startup_fail_on_bad_sqlalchemy_url(monkeypatch):
 
 
 @mark.asyncio
-@mark.dont_patch_engine_from_config
+@mark.dont_patch_engine
 async def test_async_startup_fail_on_bad_async_sqlalchemy_url(monkeypatch):
     from fastapi_sqla import asyncio_support
 

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 import httpx
 from asgi_lifespan import LifespanManager
 from fastapi import FastAPI
-from pytest import fixture, mark
+from pytest import fixture, mark, raises
 from sqlalchemy import text
 
 
@@ -48,3 +48,24 @@ async def test_fastapi_integration():
             res = await client.get("/one")
 
     assert res.json() == 1
+
+
+@mark.dont_patch_engine_from_config
+def test_startup_fail_on_bad_sqlalchemy_url(monkeypatch):
+    from fastapi_sqla import startup
+
+    monkeypatch.setenv("sqlalchemy_url", "not a valid url")
+
+    with raises(Exception):
+        startup()
+
+
+@mark.asyncio
+@mark.dont_patch_engine_from_config
+async def test_async_startup_fail_on_bad_async_sqlalchemy_url(monkeypatch):
+    from fastapi_sqla import asyncio_support
+
+    monkeypatch.setenv("async_sqlalchemy_url", "not a valid url")
+
+    with raises(Exception):
+        await asyncio_support.startup()

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -16,7 +16,7 @@ def case_sensitive_environ(environ, request):
         yield values
 
 
-@mark.dont_patch_engine
+@mark.dont_patch_engines
 def test_startup(case_sensitive_environ):
     from fastapi_sqla import _Session, startup
 
@@ -50,7 +50,7 @@ async def test_fastapi_integration():
     assert res.json() == 1
 
 
-@mark.dont_patch_engine
+@mark.dont_patch_engines
 def test_startup_fail_on_bad_sqlalchemy_url(monkeypatch):
     from fastapi_sqla import startup
 
@@ -61,7 +61,7 @@ def test_startup_fail_on_bad_sqlalchemy_url(monkeypatch):
 
 
 @mark.asyncio
-@mark.dont_patch_engine
+@mark.dont_patch_engines
 async def test_async_startup_fail_on_bad_async_sqlalchemy_url(monkeypatch):
     from fastapi_sqla import asyncio_support
 

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -54,7 +54,7 @@ async def test_fastapi_integration():
 def test_startup_fail_on_bad_sqlalchemy_url(monkeypatch):
     from fastapi_sqla import startup
 
-    monkeypatch.setenv("sqlalchemy_url", "not a valid url")
+    monkeypatch.setenv("sqlalchemy_url", "postgresql://postgres@localhost/notexisting")
 
     with raises(Exception):
         startup()
@@ -65,7 +65,9 @@ def test_startup_fail_on_bad_sqlalchemy_url(monkeypatch):
 async def test_async_startup_fail_on_bad_async_sqlalchemy_url(monkeypatch):
     from fastapi_sqla import asyncio_support
 
-    monkeypatch.setenv("async_sqlalchemy_url", "not a valid url")
+    monkeypatch.setenv(
+        "async_sqlalchemy_url", "postgresql+asyncpg://postgres@localhost/notexisting"
+    )
 
     with raises(Exception):
         await asyncio_support.startup()


### PR DESCRIPTION
## Description 

* fastapi-sqla does not obviously fail at startup if badly configured: Fail early, fail fast by querying db at startup using the sqla sessions configured.

## Related JIRA issues

* [DIA-38713]

## Related PRs

<!-- * #123 -->
<!-- * dialoguemd/scribe#1234  -->


<!-- 📋 Checklist:
1. Follows [Commit Convention] and [Code Review guidelines]
   - example: feat(lang): add German language - DIA-12345
2. Relevant labels set
3. Draft PR for WIP
4. Requested from and notified to a team

[Commit Convention]: https://www.notion.so/godialogue/Commit-Convention-84fd9a4c149e48c998d760f1c9176df0
[Code Review guidelines]: https://www.notion.so/godialogue/Code-Review-c5f3fcd185ca49aca73ade497c398fe9  -->


[DIA-38713]: https://dialoguemd.atlassian.net/browse/DIA-38713?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ