### PR TITLE
fix: aws_iam_rds_support independant from startup event handlers

### DIFF
--- a/fastapi_sqla/__init__.py
+++ b/fastapi_sqla/__init__.py
@@ -61,7 +61,8 @@ def setup(app: FastAPI):
     config = Config()
 
     if config.aws_rds_iam_enabled:
-        app.add_event_handler("startup", aws_rds_iam_support.startup)
+        app.add_event_handler("startup", aws_rds_iam_support.setup)
+        app.add_event_handler("shutdown", aws_rds_iam_support.tear_down)
 
     app.add_event_handler("startup", startup)
     app.middleware("http")(add_session_to_request)

--- a/fastapi_sqla/_pytest_plugin.py
+++ b/fastapi_sqla/_pytest_plugin.py
@@ -104,6 +104,17 @@ def engine_from_config(request, db_url, sqla_connection, sqla_transaction):
             yield engine_from_config
 
 
+@fixture(autouse=True)
+def patch_sqla_event_listen(request):
+    """So that aws_rds_iam_support does not interfere when running tests."""
+    if "dont_patch_sqla_event" in request.keywords:
+        yield
+
+    else:
+        with patch("fastapi_sqla.aws_rds_iam_support.event") as mock_event:
+            yield mock_event
+
+
 @fixture
 def sqla_transaction(sqla_connection):
     transaction = sqla_connection.begin()

--- a/fastapi_sqla/asyncio_support.py
+++ b/fastapi_sqla/asyncio_support.py
@@ -8,8 +8,6 @@ from sqlalchemy.ext.asyncio import AsyncSession as SqlaAsyncSession
 from sqlalchemy.ext.asyncio import create_async_engine
 from sqlalchemy.orm.session import sessionmaker
 
-from . import aws_rds_iam_support
-
 logger = structlog.get_logger(__name__)
 _ASYNC_SESSION_KEY = "fastapi_sqla_async_session"
 _AsyncSession = sessionmaker(class_=SqlaAsyncSession)
@@ -18,7 +16,6 @@ _AsyncSession = sessionmaker(class_=SqlaAsyncSession)
 async def startup():
     async_sqlalchemy_url = os.environ["async_sqlalchemy_url"]
     engine = create_async_engine(async_sqlalchemy_url)
-    aws_rds_iam_support.setup(engine.sync_engine)
     _AsyncSession.configure(bind=engine, expire_on_commit=False)
 
     # Fail early:

--- a/fastapi_sqla/aws_rds_iam_support.py
+++ b/fastapi_sqla/aws_rds_iam_support.py
@@ -6,16 +6,13 @@ except ImportError as err:
     boto3_installed = False
     boto3_installed_err = str(err)
 
-from pydantic import BaseSettings
 from sqlalchemy import event
+from sqlalchemy.engine import Engine
 
 
-def setup(engine):
-    config = Config()
-
-    if config.aws_rds_iam_enabled:
-        assert boto3_installed, boto3_installed_err
-        event.listen(engine, "do_connect", set_connection_token)
+def startup():
+    assert boto3_installed, boto3_installed_err
+    event.listen(Engine, "do_connect", set_connection_token)
 
 
 def get_authentication_token(host, port, user):
@@ -29,10 +26,3 @@ def set_connection_token(dialect, conn_rec, cargs, cparams):
     cparams["password"] = get_authentication_token(
         host=cparams["host"], port=cparams.get("port", 5432), user=cparams["user"]
     )
-
-
-class Config(BaseSettings):
-    aws_rds_iam_enabled: bool = False
-
-    class Config:
-        env_prefix = "fastapi_sqla_"

--- a/tests/test_aws_rds_iam_support.py
+++ b/tests/test_aws_rds_iam_support.py
@@ -6,7 +6,7 @@ from pytest import fixture, mark
 from sqlalchemy import event
 from sqlalchemy.engine import Engine
 
-pytestmark = [mark.dont_patch_engines, mark.require_boto3]
+pytestmark = [mark.dont_patch_engines, mark.dont_patch_sqla_event, mark.require_boto3]
 
 
 @fixture

--- a/tests/test_aws_rds_iam_support.py
+++ b/tests/test_aws_rds_iam_support.py
@@ -1,0 +1,54 @@
+from unittest.mock import call, patch
+
+from asgi_lifespan import LifespanManager
+from fastapi import FastAPI
+from pytest import fixture, mark
+from sqlalchemy import event
+from sqlalchemy.engine import Engine
+
+pytestmark = [mark.dont_patch_engines, mark.require_boto3]
+
+
+@fixture
+def tear_down():
+    from fastapi_sqla.aws_rds_iam_support import set_connection_token
+
+    yield
+    event.remove(Engine, "do_connect", set_connection_token)
+
+
+@fixture
+async def app(monkeypatch, tear_down):
+    from fastapi_sqla import setup
+
+    app = FastAPI()
+
+    monkeypatch.setenv("fastapi_sqla_aws_rds_iam_enabled", True)
+
+    setup(app)
+
+    async with LifespanManager(app):
+        yield app
+
+
+@fixture(autouse=True)
+def boto_client_mock():
+    with patch("fastapi_sqla.aws_rds_iam_support.boto3.Session") as mock_session:
+        yield mock_session.return_value.client.return_value
+
+
+@mark.require_asyncpg
+@mark.sqlalchemy("1.4")
+def test_with_async(boto_client_mock, db_host, db_user, app):
+    boto_client_mock.generate_db_auth_token.call_count == 2
+
+    call1, call2 = boto_client_mock.generate_db_auth_token.call_args_list
+
+    assert call1 == call2 == call(DBHostname=db_host, Port=5432, DBUsername=db_user)
+
+
+@mark.sqlalchemy("1.3")
+def test_without_async(boto_client_mock, db_host, db_user, app):
+    boto_client_mock.generate_db_auth_token.assert_called_once_with(
+        DBHostname=db_host, Port=5432, DBUsername=db_user
+    )

--- a/tests/test_aws_rds_iam_support.py
+++ b/tests/test_aws_rds_iam_support.py
@@ -3,8 +3,6 @@ from unittest.mock import call, patch
 from asgi_lifespan import LifespanManager
 from fastapi import FastAPI
 from pytest import fixture, mark
-from sqlalchemy import event
-from sqlalchemy.engine import Engine
 
 pytestmark = [mark.dont_patch_engines, mark.dont_patch_sqla_event, mark.require_boto3]
 

--- a/tests/test_aws_rds_iam_support.py
+++ b/tests/test_aws_rds_iam_support.py
@@ -10,15 +10,7 @@ pytestmark = [mark.dont_patch_engines, mark.dont_patch_sqla_event, mark.require_
 
 
 @fixture
-def tear_down():
-    from fastapi_sqla.aws_rds_iam_support import set_connection_token
-
-    yield
-    event.remove(Engine, "do_connect", set_connection_token)
-
-
-@fixture
-async def app(monkeypatch, tear_down):
+async def app(monkeypatch):
     from fastapi_sqla import setup
 
     app = FastAPI()

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -1,4 +1,4 @@
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 import httpx
 from asgi_lifespan import LifespanManager


### PR DESCRIPTION
## Description 

* `aws_rds_iam_support` does not depend anymore on unrelated startup handlers;
* Move config in top level module
* Have a separated file for `aws_rds_iam_support` tests

## Related JIRA issues

* [DIA-XXXXX]

## Related PRs

<!-- * #123 -->
<!-- * dialoguemd/scribe#1234  -->



<!-- 📋 Checklist:
1. Follows [Commit Convention] and [Code Review guidelines]
   - example: feat(lang): add German language - DIA-12345
2. Relevant labels set
3. Draft PR for WIP
4. Requested from and notified to a team

[Commit Convention]: https://www.notion.so/godialogue/Commit-Convention-84fd9a4c149e48c998d760f1c9176df0
[Code Review guidelines]: https://www.notion.so/godialogue/Code-Review-c5f3fcd185ca49aca73ade497c398fe9  -->
