### PR TITLE
fix: pagination fail non scalar JSON results - DIA-40003

### DIFF
--- a/fastapi_sqla/__init__.py
+++ b/fastapi_sqla/__init__.py
@@ -291,7 +291,7 @@ def _paginate(
     page_number = offset / limit + 1
     query = query.offset(offset).limit(limit)
     result = session.execute(query)
-    data = iter(result.unique().scalars() if scalars else result.unique().mappings())
+    data = iter(result.unique().scalars() if scalars else result.mappings())
     return Page[T](
         data=data,
         meta={

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -6,7 +6,7 @@ from faker import Faker
 from fastapi import Depends, FastAPI
 from pydantic import BaseModel
 from pytest import fixture, mark, param
-from sqlalchemy import MetaData, JSON, Table, cast, func, select, text
+from sqlalchemy import JSON, MetaData, Table, cast, func, select, text
 from sqlalchemy.orm import joinedload, relationship
 
 


### PR DESCRIPTION
## Description 

* When a non-scalar query has a JSON column, pagination fails:
  ```
  sqlalchemy.exc.InvalidRequestError: 
  Can't apply uniqueness to row tuple containing value of type JSON(); 
  this datatype produces non-hashable values
  ```
* [Example of failure](https://app.circleci.com/pipelines/github/dialoguemd/fastapi-sqla/436/workflows/3712f9fb-e79e-4413-933b-65ecfe16797e)

## Related JIRA issues

* [DIA-40003]

## Related PRs

<!-- * #123 -->
<!-- * dialoguemd/scribe#1234  -->



<!-- 📋 Checklist:
1. Follows [Commit Convention] and [Code Review guidelines]
   - example: feat(lang): add German language - DIA-12345
2. Relevant labels set
3. Draft PR for WIP
4. Requested from and notified to a team

[Commit Convention]: https://www.notion.so/godialogue/Commit-Convention-84fd9a4c149e48c998d760f1c9176df0
[Code Review guidelines]: https://www.notion.so/godialogue/Code-Review-c5f3fcd185ca49aca73ade497c398fe9  -->


[DIA-40003]: https://dialoguemd.atlassian.net/browse/DIA-40003?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ