### PR TITLE
chore: prepare fastapi-sqla to be compliant with sqlalchemy 2.0 - DIA-40134

### DIFF
--- a/fastapi_sqla/_pytest_plugin.py
+++ b/fastapi_sqla/_pytest_plugin.py
@@ -76,7 +76,10 @@ def db_migration(db_url, sqla_connection, alembic_ini_path):
     alembic_config = Config(file_=alembic_ini_path)
     alembic_config.set_main_option("sqlalchemy.url", db_url)
 
-    sqla_connection.execute(text("DROP SCHEMA public CASCADE; CREATE SCHEMA public;"))
+    with sqla_connection.begin():
+        sqla_connection.execute(
+            text("DROP SCHEMA public CASCADE; CREATE SCHEMA public;")
+        )
 
     command.upgrade(alembic_config, "head")
     yield

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,3 +110,7 @@ extras =
     tests
 commands = pytest -vv --cov={envsitepackagesdir}/fastapi_sqla --cov-report xml --cov-report html --junitxml=test-reports/pytest/junit.xml
 """
+
+[tool.black]
+exclude = ".mypy_cache|.pytest_cache|.vscode|.eggs|venv"
+--skip-magic-trailing-comma = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,6 +8,9 @@ addopts =
     --cov-report term
     --cov-report term-missing
 
+filterwarnings =
+    error:.*removed in version 2\.0.*:
+
 [pytest-watch]
 ext = .py,.yaml,.cfg,.yml
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,11 +4,11 @@ from unittest.mock import patch
 
 from faker import Faker
 from pytest import fixture, skip
-from sqlalchemy import engine_from_config
-from sqlalchemy.orm.session import close_all_sessions
+
+# Must be done before importing anything from sqlalchemy:
+os.environ["SQLALCHEMY_WARN_20"] = "true"
 
 pytest_plugins = ["fastapi_sqla._pytest_plugin", "pytester"]
-os.environ["SQLALCHEMY_WARN_20"] = "true"
 
 
 def pytest_configure(config):
@@ -70,12 +70,15 @@ def environ(db_url, sqla_version_tuple, async_sqlalchemy_url):
 
 @fixture(scope="session")
 def engine(environ):
+    from sqlalchemy import engine_from_config
+
     engine = engine_from_config(environ, prefix="sqlalchemy_")
     return engine
 
 
 @fixture(autouse=True)
-def tear_down():
+def tear_down(environ):
+    from sqlalchemy.orm.session import close_all_sessions
     import fastapi_sqla
 
     yield

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import importlib
+import os
 from unittest.mock import patch
 
 from faker import Faker
@@ -7,6 +8,7 @@ from sqlalchemy import engine_from_config
 from sqlalchemy.orm.session import close_all_sessions
 
 pytest_plugins = ["fastapi_sqla._pytest_plugin", "pytester"]
+os.environ["SQLALCHEMY_WARN_20"] = "true"
 
 
 def pytest_configure(config):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -79,6 +79,7 @@ def engine(environ):
 @fixture(autouse=True)
 def tear_down(environ):
     from sqlalchemy.orm.session import close_all_sessions
+
     import fastapi_sqla
 
     yield

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,7 @@ def pytest_configure(config):
     config.addinivalue_line(
         "markers", "require_boto3: skip test if boto3 is not installed"
     )
+    config.addinivalue_line("markers", "dont_patch_engines: do not patch engines")
 
 
 @fixture(scope="session")
@@ -52,7 +53,11 @@ def is_boto3_installed():
 
 @fixture(scope="session", autouse=True)
 def environ(db_url, sqla_version_tuple, async_sqlalchemy_url):
-    values = {"sqlalchemy_url": db_url, "PYTHONASYNCIODEBUG": "1"}
+    values = {
+        "PYTHONASYNCIODEBUG": "1",
+        "sqlalchemy_url": db_url,
+        "SQLALCHEMY_WARN_20": "true",
+    }
 
     if sqla_version_tuple >= (1, 4, 0) and is_asyncpg_installed():
         values["async_sqlalchemy_url"] = async_sqlalchemy_url

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -6,11 +6,13 @@ from sqlalchemy.exc import NoSuchTableError
 @fixture(autouse=True, scope="module")
 def setup_tear_down(engine):
     with engine.connect() as connection:
-        connection.execute(
-            text("CREATE TABLE IF NOT EXISTS test_table (id integer primary key)")
-        )
+        with connection.begin():
+            connection.execute(
+                text("CREATE TABLE IF NOT EXISTS test_table (id integer primary key)")
+            )
         yield
-        connection.execute(text("DROP TABLE test_table"))
+        with connection.begin():
+            connection.execute(text("DROP TABLE test_table"))
 
 
 def test_startup_reflect_test_table():

--- a/tests/test_open_session.py
+++ b/tests/test_open_session.py
@@ -5,11 +5,16 @@ from sqlalchemy.exc import IntegrityError
 
 @fixture(autouse=True, scope="module")
 def module_setup_tear_down(engine, sqla_connection):
-    engine.execute(
-        "CREATE TABLE IF NOT EXISTS test_table (id integer primary key, value varchar)"
-    )
+    with sqla_connection.begin():
+        sqla_connection.execute(
+            text(
+                "CREATE TABLE IF NOT EXISTS test_table   "
+                "(id integer primary key, value varchar) "
+            )
+        )
     yield
-    engine.execute("DROP TABLE test_table")
+    with sqla_connection.begin():
+        sqla_connection.execute(text("DROP TABLE test_table"))
 
 
 @fixture(autouse=True)

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -66,7 +66,7 @@ def test_all_opened_sessions_are_within_the_same_transaction(
     session.commit()
 
     other_session = _Session(bind=sqla_connection)
-    assert other_session.query(singer_cls).get(1)
+    assert other_session.get(singer_cls, 1)
 
 
 @mark.require_asyncpg

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -57,7 +57,8 @@ async def test_async_session_fixture_does_not_write_in_db(
         ).scalar() == 0
 
 
-def test_all_opened_sessions_are_within_the_same_transaction(
+@mark.sqlalchemy("1.4")
+def test_sqla_14_all_opened_sessions_are_within_the_same_transaction(
     sqla_connection, session, singer_cls
 ):
     from fastapi_sqla import _Session
@@ -66,7 +67,22 @@ def test_all_opened_sessions_are_within_the_same_transaction(
     session.commit()
 
     other_session = _Session(bind=sqla_connection)
+
     assert other_session.get(singer_cls, 1)
+
+
+@mark.sqlalchemy("1.3")
+def test_sqla_13_all_opened_sessions_are_within_the_same_transaction(
+    sqla_connection, session, singer_cls
+):
+    from fastapi_sqla import _Session
+
+    session.add(singer_cls(id=1, name="Bob Marley", country="Jamaica"))
+    session.commit()
+
+    other_session = _Session(bind=sqla_connection)
+
+    assert other_session.query(singer_cls).get(1)
 
 
 @mark.require_asyncpg

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -94,7 +94,7 @@ def test_sync_startup_with_aws_rds_iam_enabled(
 ):
     from fastapi_sqla import startup
 
-    monkeypatch.setenv("fastapi_sqla_aws_rds_iam_enabled", True)
+    monkeypatch.setenv("fastapi_sqla_aws_rds_iam_enabled", "true")
 
     startup()
 
@@ -113,7 +113,7 @@ async def test_async_startup_with_aws_rds_iam_enabled(
 ):
     from fastapi_sqla.asyncio_support import startup
 
-    monkeypatch.setenv("fastapi_sqla_aws_rds_iam_enabled", True)
+    monkeypatch.setenv("fastapi_sqla_aws_rds_iam_enabled", "true")
     monkeypatch.setenv("async_sqlalchemy_url", async_sqlalchemy_url)
 
     await startup()


### PR DESCRIPTION
## Description 

* Prepare fastapi-sqla to be compliant with [SQLAlchemy 2.0](https://docs.sqlalchemy.org/en/20/changelog/migration_20.html);
* Run tests with [`SQLALCHEMY_WARN_20`](https://docs.sqlalchemy.org/en/20/changelog/migration_20.html#migration-to-2-0-step-two-turn-on-removedin20warnings) environment variable;
* Fix sqla and pytest warnings;

## Related JIRA issues

* [DIA-40134]

## Related PRs

<!-- * #123 -->
<!-- * dialoguemd/scribe#1234  -->



<!-- 📋 Checklist:
1. Follows [Commit Convention] and [Code Review guidelines]
   - example: feat(lang): add German language - DIA-12345
2. Relevant labels set
3. Draft PR for WIP
4. Requested from and notified to a team

[Commit Convention]: https://www.notion.so/godialogue/Commit-Convention-84fd9a4c149e48c998d760f1c9176df0
[Code Review guidelines]: https://www.notion.so/godialogue/Code-Review-c5f3fcd185ca49aca73ade497c398fe9  -->


[DIA-40134]: https://dialoguemd.atlassian.net/browse/DIA-40134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ