### PR TITLE
fix: session fixture does not need to re-open a transaction - DIA-40134

### DIFF
--- a/fastapi_sqla/_pytest_plugin.py
+++ b/fastapi_sqla/_pytest_plugin.py
@@ -122,7 +122,7 @@ def sqla_transaction(sqla_connection):
 
 
 @fixture
-def session(sqla_transaction, sqla_connection, sqla_version_tuple):
+def session(sqla_transaction, sqla_connection):
     """Sqla session to use when creating db fixtures.
 
     While it does not write any record in DB, the application will still be able to
@@ -130,16 +130,7 @@ def session(sqla_transaction, sqla_connection, sqla_version_tuple):
     """
     import fastapi_sqla
 
-    session = fastapi_sqla._Session(bind=sqla_connection)
-
-    if sqla_version_tuple >= (1, 4, 0):
-        with session.begin():
-            yield session
-            session.rollback()
-    else:
-        with session.begin(subtransactions=True):
-            session.begin_nested()
-            yield session
+    yield fastapi_sqla._Session(bind=sqla_connection)
 
 
 def format_async_async_sqlalchemy_url(url):


### PR DESCRIPTION
## Description 

* Session fixture does not need to open a transaction as there is already one being opened at connection level.

## Related JIRA issues

* [DIA-40134]

## Related PRs

<!-- * #123 -->
<!-- * dialoguemd/scribe#1234  -->



<!-- 📋 Checklist:
1. Follows [Commit Convention] and [Code Review guidelines]
   - example: feat(lang): add German language - DIA-12345
2. Relevant labels set
3. Draft PR for WIP
4. Requested from and notified to a team

[Commit Convention]: https://www.notion.so/godialogue/Commit-Convention-84fd9a4c149e48c998d760f1c9176df0
[Code Review guidelines]: https://www.notion.so/godialogue/Code-Review-c5f3fcd185ca49aca73ade497c398fe9  -->


[DIA-40134]: https://dialoguemd.atlassian.net/browse/DIA-40134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ