### PR TITLE
fix: rollback logs warning on clean sessions [DIA-40867]

### DIFF
--- a/fastapi_sqla/__init__.py
+++ b/fastapi_sqla/__init__.py
@@ -166,12 +166,13 @@ async def add_session_to_request(request: Request, call_next):
 
         response = await call_next(request)
 
+        is_dirty = bool(session.dirty)
+
         loop = asyncio.get_running_loop()
 
         # try to commit after response, so that we can return a proper 500 response
         # and not raise a true internal server error
         if response.status_code < 400:
-
             try:
                 await loop.run_in_executor(None, session.commit)
             except Exception:
@@ -183,8 +184,8 @@ async def add_session_to_request(request: Request, call_next):
         if response.status_code >= 400:
             # If ever a route handler returns an http exception, we do not want the
             # session opened by current context manager to commit anything in db.
-            if session.dirty:
-                # optimistically only log if there's uncommited changes
+            if is_dirty:
+                # optimistically only log if there were uncommitted changes
                 logger.warning(
                     "http error, rolling back possibly uncommitted changes",
                     status_code=response.status_code,

--- a/fastapi_sqla/__init__.py
+++ b/fastapi_sqla/__init__.py
@@ -166,7 +166,7 @@ async def add_session_to_request(request: Request, call_next):
 
         response = await call_next(request)
 
-        is_dirty = bool(session.dirty)
+        is_dirty = bool(session.dirty or session.deleted or session.new)
 
         loop = asyncio.get_running_loop()
 


### PR DESCRIPTION
## Description 

Currently, when fastapi-sqla encounters an http error, it will rollback the session, regardless of the error, and log an associated warning. However, this causes a lot of log noise for inconsequential rollbacks (e.g. 404s will also trigger this warning). 

This takes an optimistic approach and checks if a session is dirty (which _could_ but doesn't necessarily indicate that data will be written to DB) before logging the warning, effectively silencing the log when a rollback is expected to be no-op.

See https://app.datadoghq.com/logs?query=app%3Anotepad%20env%3Adev-ca2%20scope%3Acore&agg_m=count&agg_t=count&event=AQAAAYAewq6X7ACj4AAAAABBWUFld3JUdEFBQmxxbk1TTEppcE1nQUk&index=main&from_ts=1649769234000&to_ts=1649783634000&live=false for an example of such log that this would silence.


