### PR TITLE
fix: cache rds client [DIA-44302]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,7 +110,7 @@ executors:
   python-postgres:
     docker:
       - image: cimg/python:3.9
-      - image: postgres:10.12
+      - image: postgres:14.4
         name: postgres
         environment:
           POSTGRES_HOST_AUTH_METHOD: trust

--- a/fastapi_sqla/aws_rds_iam_support.py
+++ b/fastapi_sqla/aws_rds_iam_support.py
@@ -6,6 +6,8 @@ except ImportError as err:
     boto3_installed = False
     boto3_installed_err = str(err)
 
+from functools import cache
+from this import d
 from pydantic import BaseSettings
 from sqlalchemy import event
 
@@ -17,10 +19,13 @@ def setup(engine):
         assert boto3_installed, boto3_installed_err
         event.listen(engine, "do_connect", set_connection_token)
 
+@cache
+def get_rds_client():
+    return boto3.client("rds")
+
 
 def get_authentication_token(host, port, user):
-    session = boto3.Session()
-    client = session.client("rds")
+    client = get_rds_client()
     token = client.generate_db_auth_token(DBHostname=host, Port=port, DBUsername=user)
     return token
 


### PR DESCRIPTION
## Description 
Cache the rds client to speed up connection creation. Only the first connection to be created will have a hit on performance and the others will be faster to create.

## Related PRs

<!-- * #123 -->
<!-- * dialoguemd/scribe#1234  -->



<!-- 📋 Checklist:
1. Follows [Commit Convention] and [Code Review guidelines]
   - example: feat(lang): add German language - DIA-12345
2. Relevant labels set
3. Draft PR for WIP
4. Requested from and notified to a team

[Commit Convention]: https://www.notion.so/godialogue/Commit-Convention-84fd9a4c149e48c998d760f1c9176df0
[Code Review guidelines]: https://www.notion.so/godialogue/Code-Review-c5f3fcd185ca49aca73ade497c398fe9  -->
