### PR TITLE
fix: remove autoused fixtures + set dont_patch_engine marker in plugin - DM-6561

### DIFF
--- a/fastapi_sqla/_pytest_plugin.py
+++ b/fastapi_sqla/_pytest_plugin.py
@@ -16,11 +16,8 @@ except ImportError:
     asyncio_support = False
 
 
-@fixture(scope="session")
-def sqla_version_tuple():
-    from sqlalchemy import __version__
-
-    return tuple(int(i) for i in __version__.split("."))
+def pytest_configure(config):
+    config.addinivalue_line("markers", "dont_patch_engines: do not patch sqla engines")
 
 
 @fixture(scope="session")

--- a/fastapi_sqla/_pytest_plugin.py
+++ b/fastapi_sqla/_pytest_plugin.py
@@ -183,6 +183,7 @@ if asyncio_support:
         yield session
         await session.close()
 
+
 else:
 
     @fixture

--- a/fastapi_sqla/_pytest_plugin.py
+++ b/fastapi_sqla/_pytest_plugin.py
@@ -94,7 +94,7 @@ def sqla_modules():
     )
 
 
-@fixture(autouse=True)
+@fixture
 def sqla_reflection(sqla_modules, sqla_connection, db_url):
     import fastapi_sqla
 
@@ -102,7 +102,7 @@ def sqla_reflection(sqla_modules, sqla_connection, db_url):
     fastapi_sqla.Base.prepare(sqla_connection)
 
 
-@fixture(autouse=True)
+@fixture
 def engine_from_config(request, db_url, sqla_connection, sqla_transaction):
     """So that all DB operations are never written to db for real."""
     if "dont_patch_engines" in request.keywords:
@@ -122,7 +122,7 @@ def sqla_transaction(sqla_connection):
 
 
 @fixture
-def session(sqla_transaction, sqla_connection):
+def session(sqla_transaction, sqla_connection, sqla_reflection, engine_from_config):
     """Sqla session to use when creating db fixtures.
 
     While it does not write any record in DB, the application will still be able to
@@ -159,7 +159,7 @@ if asyncio_support:
             yield connection
             await connection.rollback()
 
-    @fixture(autouse=True)
+    @fixture
     async def patch_async_sessionmaker(
         async_sqlalchemy_url, async_sqla_connection, request
     ):
@@ -175,7 +175,9 @@ if asyncio_support:
                 yield create_async_engine
 
     @fixture
-    async def async_session(async_sqla_connection):
+    async def async_session(
+        async_sqla_connection, sqla_reflection, patch_async_sessionmaker
+    ):
         from fastapi_sqla.asyncio_support import _AsyncSession
 
         session = _AsyncSession(bind=async_sqla_connection)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,7 +25,6 @@ def pytest_configure(config):
     config.addinivalue_line(
         "markers", "require_boto3: skip test if boto3 is not installed"
     )
-    config.addinivalue_line("markers", "dont_patch_engines: do not patch engines")
 
 
 @fixture(scope="session")

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -6,6 +6,8 @@ from fastapi import FastAPI
 from pytest import fixture, mark, raises
 from sqlalchemy import text
 
+pytestmark = mark.usefixtures("engine_from_config")
+
 
 @fixture(params=[True, False])
 def case_sensitive_environ(environ, request):

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -6,7 +6,7 @@ from fastapi import FastAPI
 from pytest import fixture, mark, raises
 from sqlalchemy import text
 
-pytestmark = mark.usefixtures("engine_from_config")
+pytestmark = mark.usefixtures("patch_engine_from_config", "patch_create_async_engine")
 
 
 @fixture(params=[True, False])


### PR DESCRIPTION
## Description 

* The _autoused_ fixtures force a connection to postgres server even if the test being run does not require a connection to postgres;
* The `dont_patch_engine` marker is now set by plugin rather than in conftest;
* Removed unused fixture `sqla_version_tuple`;

## Related JIRA issues

* [DM-6561]

## Related PRs

* dialoguemd/engage#22
<!-- * #123 -->
<!-- * dialoguemd/scribe#1234  -->



<!-- 📋 Checklist:
1. Follows [Commit Convention] and [Code Review guidelines]
   - example: feat(lang): add German language - DIA-12345
2. Relevant labels set
3. Draft PR for WIP
4. Requested from and notified to a team

[Commit Convention]: https://www.notion.so/godialogue/Commit-Convention-84fd9a4c149e48c998d760f1c9176df0
[Code Review guidelines]: https://www.notion.so/godialogue/Code-Review-c5f3fcd185ca49aca73ade497c398fe9  -->


[DM-6561]: https://dialoguemd.atlassian.net/browse/DM-6561?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ