### PR TITLE
fix: importing AsyncSession from fastapi_sqla - DIA-46202

### DIFF
--- a/fastapi_sqla/__init__.py
+++ b/fastapi_sqla/__init__.py
@@ -1,371 +1,61 @@
-import asyncio
-import math
 import os
-from collections.abc import Callable, Generator
-from contextlib import contextmanager
-from functools import singledispatch
-from typing import Generic, Optional, TypeVar, Union
 
-import structlog
-from fastapi import Depends, FastAPI, Query, Request
-from fastapi.concurrency import contextmanager_in_threadpool
-from fastapi.responses import PlainTextResponse
-from pydantic import BaseModel, Field
-from pydantic.generics import GenericModel
-from sqlalchemy import engine_from_config, text
-from sqlalchemy.engine import Engine
-from sqlalchemy.ext.declarative import DeferredReflection
-from sqlalchemy.orm import Query as LegacyQuery
-from sqlalchemy.orm.session import Session as SqlaSession
-from sqlalchemy.orm.session import sessionmaker
-from sqlalchemy.sql import Select, func, select
+from fastapi import FastAPI
 
-from . import aws_rds_iam_support
+from fastapi_sqla import sqla
+from fastapi_sqla.sqla import (
+    Base,
+    Page,
+    Paginate,
+    PaginateSignature,
+    Pagination,
+    Session,
+    open_session,
+)
+
+__all__ = [
+    "Base",
+    "Page",
+    "Paginate",
+    "PaginateSignature",
+    "Pagination",
+    "Session",
+    "open_session",
+]
+
 
 try:
-    from sqlalchemy.orm import declarative_base
-except ImportError:
-    from sqlalchemy.ext.declarative import declarative_base
+    from fastapi_sqla import asyncio_support
+    from fastapi_sqla.asyncio_support import (  # noqa
+        AsyncPaginate,
+        AsyncPagination,
+        AsyncSession,
+    )
+    from fastapi_sqla.asyncio_support import open_session as open_async_session  # noqa
 
-try:
-    from . import asyncio_support
-    from .asyncio_support import AsyncPaginate, AsyncPagination, AsyncSession
-    from .asyncio_support import open_session as open_async_session
+    __all__ += [
+        "AsyncPaginate",
+        "AsyncPagination",
+        "AsyncSession",
+        "open_async_session",
+    ]
+
 except ImportError as err:
     asyncio_support = False
     asyncio_support_err = str(err)
 
-__all__ = [
-    "AsyncPaginate",
-    "AsyncPagination",
-    "AsyncSession",
-    "Base",
-    "Page",
-    "Paginate",
-    "Session",
-    "open_async_session",
-    "open_session",
-    "setup",
-]
-
-logger = structlog.get_logger(__name__)
-
-_SESSION_KEY = "fastapi_sqla_session"
-
-_Session = sessionmaker()
-
-
-def new_engine(*, envvar_prefix: str = None) -> Engine:
-    envvar_prefix = envvar_prefix if envvar_prefix else "sqlalchemy_"
-    lowercase_environ = {
-        k.lower(): v for k, v in os.environ.items() if k.lower() != "sqlalchemy_warn_20"
-    }
-    return engine_from_config(lowercase_environ, prefix=envvar_prefix)
-
-
-def is_async_dialect(engine):
-    return engine.dialect.is_async if hasattr(engine.dialect, "is_async") else False
-
 
 def setup(app: FastAPI):
-    engine = new_engine()
+    engine = sqla.new_engine()
 
-    if not is_async_dialect(engine):
-        app.add_event_handler("startup", startup)
-        app.middleware("http")(add_session_to_request)
+    if not sqla.is_async_dialect(engine):
+        app.add_event_handler("startup", sqla.startup)
+        app.middleware("http")(sqla.add_session_to_request)
 
-    has_async_config = "async_sqlalchemy_url" in os.environ or is_async_dialect(engine)
+    has_async_config = "async_sqlalchemy_url" in os.environ or sqla.is_async_dialect(
+        engine
+    )
     if has_async_config:
         assert asyncio_support, asyncio_support_err
         app.add_event_handler("startup", asyncio_support.startup)
         app.middleware("http")(asyncio_support.add_session_to_request)
-
-
-def startup():
-    engine = new_engine()
-    aws_rds_iam_support.setup(engine.engine)
-
-    # Fail early:
-    try:
-        with engine.connect() as connection:
-            connection.execute(text("select 'OK'"))
-    except Exception:
-        logger.critical(
-            "Fail querying db: is sqlalchemy_url envvar correctly configured?"
-        )
-        raise
-
-    Base.prepare(engine)
-    _Session.configure(bind=engine)
-    logger.info("startup", engine=engine)
-
-
-class Base(declarative_base(cls=DeferredReflection)):  # type: ignore
-    __abstract__ = True
-
-
-class Session(SqlaSession):
-    def __new__(cls, request: Request) -> SqlaSession:
-        """Yield the sqlalchmey session for that request.
-
-        It is meant to be used as a FastAPI dependency::
-
-            from fastapi import APIRouter, Depends
-            from fastapi_sqla import Session
-
-            router = APIRouter()
-
-            @router.get("/users")
-            def get_users(session: Session = Depends()):
-                pass
-        """
-        try:
-            return request.scope[_SESSION_KEY]
-        except KeyError:  # pragma: no cover
-            raise Exception(
-                "No session found in request, please ensure you've setup fastapi_sqla."
-            )
-
-
-@contextmanager
-def open_session() -> Generator[Session, None, None]:
-    """Context manager that opens a session and properly closes session when exiting.
-
-    If no exception is raised before exiting context, session is committed when exiting
-    context. If an exception is raised, session is rollbacked.
-    """
-    session = _Session()
-    logger.bind(db_session=session)
-
-    try:
-        yield session
-
-    except Exception:
-        logger.warning("context failed, rolling back", exc_info=True)
-        session.rollback()
-        raise
-
-    else:
-        try:
-            session.commit()
-        except Exception:
-            logger.exception("commit failed, rolling back")
-            session.rollback()
-            raise
-
-    finally:
-        session.close()
-
-
-async def add_session_to_request(request: Request, call_next):
-    """Middleware which injects a new sqla session into every request.
-
-    Handles creation of session, as well as commit, rollback, and closing of session.
-
-    Usage::
-
-        import fastapi_sqla
-        from fastapi import FastApi
-
-        app = FastApi()
-
-        fastapi_sqla.setup(app)  # includes middleware
-
-        @app.get("/users")
-        def get_users(session: fastapi_sqla.Session = Depends()):
-            return session.execute(...) # use your session here
-    """
-    async with contextmanager_in_threadpool(open_session()) as session:
-        request.scope[_SESSION_KEY] = session
-
-        response = await call_next(request)
-
-        is_dirty = bool(session.dirty or session.deleted or session.new)
-
-        loop = asyncio.get_running_loop()
-
-        # try to commit after response, so that we can return a proper 500 response
-        # and not raise a true internal server error
-        if response.status_code < 400:
-            try:
-                await loop.run_in_executor(None, session.commit)
-            except Exception:
-                logger.exception("commit failed, returning http error")
-                response = PlainTextResponse(
-                    content="Internal Server Error", status_code=500
-                )
-
-        if response.status_code >= 400:
-            # If ever a route handler returns an http exception, we do not want the
-            # session opened by current context manager to commit anything in db.
-            if is_dirty:
-                # optimistically only log if there were uncommitted changes
-                logger.warning(
-                    "http error, rolling back possibly uncommitted changes",
-                    status_code=response.status_code,
-                )
-            # since this is no-op if session is not dirty, we can always call it
-            await loop.run_in_executor(None, session.rollback)
-
-    return response
-
-
-T = TypeVar("T")
-
-
-class Item(GenericModel, Generic[T]):
-    """Item container."""
-
-    data: T
-
-
-class Collection(GenericModel, Generic[T]):
-    """Collection container."""
-
-    data: list[T]
-
-
-class Meta(BaseModel):
-    """Meta information on current page and collection"""
-
-    offset: int = Field(..., description="Current page offset")
-    total_items: int = Field(..., description="Total number of items in the collection")
-    total_pages: int = Field(..., description="Total number of pages in the collection")
-    page_number: int = Field(..., description="Current page number. Starts at 1.")
-
-
-class Page(Collection, Generic[T]):
-    """A page of the collection with info on current page and total items in meta."""
-
-    meta: Meta
-
-
-DbQuery = Union[LegacyQuery, Select]
-QueryCountDependency = Callable[..., int]
-PaginateSignature = Callable[[DbQuery, Optional[bool]], Page[T]]
-DefaultDependency = Callable[[Session, int, int], PaginateSignature]
-WithQueryCountDependency = Callable[[Session, int, int, int], PaginateSignature]
-PaginateDependency = Union[DefaultDependency, WithQueryCountDependency]
-
-
-def default_query_count(session: Session, query: DbQuery) -> int:
-    """Default function used to count items returned by a query.
-
-    It is slower than a manually written query could be: It runs the query in a
-    subquery, and count the number of elements returned.
-
-    See https://gist.github.com/hest/8798884
-    """
-    if isinstance(query, LegacyQuery):
-        result = query.count()
-
-    elif isinstance(query, Select):
-        result = session.execute(
-            select(func.count()).select_from(query.subquery())
-        ).scalar()
-
-    else:  # pragma no cover
-        raise NotImplementedError(f"Query type {type(query)!r} is not supported")
-
-    return result
-
-
-@singledispatch
-def paginate_query(
-    query: DbQuery,
-    session: Session,
-    total_items: int,
-    offset: int,
-    limit: int,
-    scalars: bool = True,
-) -> Page[T]:  # pragma no cover
-    "Dispatch on registered functions based on `query` type"
-    raise NotImplementedError(f"no paginate_query registered for type {type(query)!r}")
-
-
-@paginate_query.register
-def _paginate_legacy(
-    query: LegacyQuery,
-    session: Session,
-    total_items: int,
-    offset: int,
-    limit: int,
-    scalars: bool = True,
-) -> Page[T]:
-    total_pages = math.ceil(total_items / limit)
-    page_number = offset / limit + 1
-    return Page[T](
-        data=query.offset(offset).limit(limit).all(),
-        meta={
-            "offset": offset,
-            "total_items": total_items,
-            "total_pages": total_pages,
-            "page_number": page_number,
-        },
-    )
-
-
-@paginate_query.register
-def _paginate(
-    query: Select,
-    session: Session,
-    total_items: int,
-    offset: int,
-    limit: int,
-    *,
-    scalars: bool = True,
-) -> Page[T]:
-    total_pages = math.ceil(total_items / limit)
-    page_number = offset / limit + 1
-    query = query.offset(offset).limit(limit)
-    result = session.execute(query)
-    data = iter(result.unique().scalars() if scalars else result.mappings())
-    return Page[T](
-        data=data,
-        meta={
-            "offset": offset,
-            "total_items": total_items,
-            "total_pages": total_pages,
-            "page_number": page_number,
-        },
-    )
-
-
-def Pagination(
-    min_page_size: int = 10,
-    max_page_size: int = 100,
-    query_count: QueryCountDependency = None,
-) -> PaginateDependency:
-    def default_dependency(
-        session: Session = Depends(),
-        offset: int = Query(0, ge=0),
-        limit: int = Query(min_page_size, ge=1, le=max_page_size),
-    ) -> PaginateSignature:
-        def paginate(query: DbQuery, scalars=True) -> Page[T]:
-            total_items = default_query_count(session, query)
-            return paginate_query(
-                query, session, total_items, offset, limit, scalars=scalars
-            )
-
-        return paginate
-
-    def with_query_count_dependency(
-        session: Session = Depends(),
-        offset: int = Query(0, ge=0),
-        limit: int = Query(min_page_size, ge=1, le=max_page_size),
-        total_items: int = Depends(query_count),
-    ) -> PaginateSignature:
-        def paginate(query: DbQuery, scalars=True) -> Page[T]:
-            return paginate_query(
-                query, session, total_items, offset, limit, scalars=scalars
-            )
-
-        return paginate
-
-    if query_count:
-        return with_query_count_dependency
-    else:
-        return default_dependency
-
-
-Paginate: PaginateDependency = Pagination()

--- a/fastapi_sqla/_pytest_plugin.py
+++ b/fastapi_sqla/_pytest_plugin.py
@@ -102,13 +102,13 @@ def sqla_reflection(sqla_modules, sqla_connection, db_url):
 @fixture
 def patch_engine_from_config(request, db_url, sqla_connection, sqla_transaction):
     """So that all DB operations are never written to db for real."""
-    from fastapi_sqla import _Session
+    from fastapi_sqla.sqla import _Session
 
     if "dont_patch_engines" in request.keywords:
         yield
 
     else:
-        with patch("fastapi_sqla.engine_from_config") as engine_from_config:
+        with patch("fastapi_sqla.sqla.engine_from_config") as engine_from_config:
             engine_from_config.return_value = sqla_connection
             _Session.configure(bind=sqla_connection)
             yield engine_from_config
@@ -130,9 +130,9 @@ def session(
     While it does not write any record in DB, the application will still be able to
     access any record committed with that session.
     """
-    import fastapi_sqla
+    import fastapi_sqla.sqla
 
-    yield fastapi_sqla._Session(bind=sqla_connection)
+    yield fastapi_sqla.sqla._Session(bind=sqla_connection)
 
 
 def format_async_async_sqlalchemy_url(url):

--- a/fastapi_sqla/asyncio_support.py
+++ b/fastapi_sqla/asyncio_support.py
@@ -12,7 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession as SqlaAsyncSession
 from sqlalchemy.orm.session import sessionmaker
 from sqlalchemy.sql import Select, func, select
 
-from . import Base, Page, T, aws_rds_iam_support, new_engine
+from fastapi_sqla.sqla import Base, Page, T, aws_rds_iam_support, new_engine
 
 logger = structlog.get_logger(__name__)
 _ASYNC_SESSION_KEY = "fastapi_sqla_async_session"

--- a/fastapi_sqla/sqla.py
+++ b/fastapi_sqla/sqla.py
@@ -1,0 +1,337 @@
+import asyncio
+import math
+import os
+from collections.abc import Callable, Generator
+from contextlib import contextmanager
+from functools import singledispatch
+from typing import Generic, Optional, TypeVar, Union
+
+import structlog
+from fastapi import Depends, Query, Request
+from fastapi.concurrency import contextmanager_in_threadpool
+from fastapi.responses import PlainTextResponse
+from pydantic import BaseModel, Field
+from pydantic.generics import GenericModel
+from sqlalchemy import engine_from_config, text
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.declarative import DeferredReflection
+from sqlalchemy.orm import Query as LegacyQuery
+from sqlalchemy.orm.session import Session as SqlaSession
+from sqlalchemy.orm.session import sessionmaker
+from sqlalchemy.sql import Select, func, select
+
+from fastapi_sqla import aws_rds_iam_support
+
+try:
+    from sqlalchemy.orm import declarative_base
+except ImportError:
+    from sqlalchemy.ext.declarative import declarative_base
+
+
+logger = structlog.get_logger(__name__)
+
+_SESSION_KEY = "fastapi_sqla_session"
+
+_Session = sessionmaker()
+
+
+def new_engine(*, envvar_prefix: str = None) -> Engine:
+    envvar_prefix = envvar_prefix if envvar_prefix else "sqlalchemy_"
+    lowercase_environ = {
+        k.lower(): v for k, v in os.environ.items() if k.lower() != "sqlalchemy_warn_20"
+    }
+    return engine_from_config(lowercase_environ, prefix=envvar_prefix)
+
+
+def is_async_dialect(engine):
+    return engine.dialect.is_async if hasattr(engine.dialect, "is_async") else False
+
+
+def startup():
+    engine = new_engine()
+    aws_rds_iam_support.setup(engine.engine)
+
+    # Fail early:
+    try:
+        with engine.connect() as connection:
+            connection.execute(text("select 'OK'"))
+    except Exception:
+        logger.critical(
+            "Fail querying db: is sqlalchemy_url envvar correctly configured?"
+        )
+        raise
+
+    Base.prepare(engine)
+    _Session.configure(bind=engine)
+    logger.info("startup", engine=engine)
+
+
+class Base(declarative_base(cls=DeferredReflection)):  # type: ignore
+    __abstract__ = True
+
+
+class Session(SqlaSession):
+    def __new__(cls, request: Request) -> SqlaSession:
+        """Yield the sqlalchmey session for that request.
+
+        It is meant to be used as a FastAPI dependency::
+
+            from fastapi import APIRouter, Depends
+            from fastapi_sqla import Session
+
+            router = APIRouter()
+
+            @router.get("/users")
+            def get_users(session: Session = Depends()):
+                pass
+        """
+        try:
+            return request.scope[_SESSION_KEY]
+        except KeyError:  # pragma: no cover
+            raise Exception(
+                "No session found in request, please ensure you've setup fastapi_sqla."
+            )
+
+
+@contextmanager
+def open_session() -> Generator[Session, None, None]:
+    """Context manager that opens a session and properly closes session when exiting.
+
+    If no exception is raised before exiting context, session is committed when exiting
+    context. If an exception is raised, session is rollbacked.
+    """
+    session = _Session()
+    logger.bind(db_session=session)
+
+    try:
+        yield session
+
+    except Exception:
+        logger.warning("context failed, rolling back", exc_info=True)
+        session.rollback()
+        raise
+
+    else:
+        try:
+            session.commit()
+        except Exception:
+            logger.exception("commit failed, rolling back")
+            session.rollback()
+            raise
+
+    finally:
+        session.close()
+
+
+async def add_session_to_request(request: Request, call_next):
+    """Middleware which injects a new sqla session into every request.
+
+    Handles creation of session, as well as commit, rollback, and closing of session.
+
+    Usage::
+
+        import fastapi_sqla
+        from fastapi import FastApi
+
+        app = FastApi()
+
+        fastapi_sqla.setup(app)  # includes middleware
+
+        @app.get("/users")
+        def get_users(session: fastapi_sqla.Session = Depends()):
+            return session.execute(...) # use your session here
+    """
+    async with contextmanager_in_threadpool(open_session()) as session:
+        request.scope[_SESSION_KEY] = session
+
+        response = await call_next(request)
+
+        is_dirty = bool(session.dirty or session.deleted or session.new)
+
+        loop = asyncio.get_running_loop()
+
+        # try to commit after response, so that we can return a proper 500 response
+        # and not raise a true internal server error
+        if response.status_code < 400:
+            try:
+                await loop.run_in_executor(None, session.commit)
+            except Exception:
+                logger.exception("commit failed, returning http error")
+                response = PlainTextResponse(
+                    content="Internal Server Error", status_code=500
+                )
+
+        if response.status_code >= 400:
+            # If ever a route handler returns an http exception, we do not want the
+            # session opened by current context manager to commit anything in db.
+            if is_dirty:
+                # optimistically only log if there were uncommitted changes
+                logger.warning(
+                    "http error, rolling back possibly uncommitted changes",
+                    status_code=response.status_code,
+                )
+            # since this is no-op if session is not dirty, we can always call it
+            await loop.run_in_executor(None, session.rollback)
+
+    return response
+
+
+T = TypeVar("T")
+
+
+class Item(GenericModel, Generic[T]):
+    """Item container."""
+
+    data: T
+
+
+class Collection(GenericModel, Generic[T]):
+    """Collection container."""
+
+    data: list[T]
+
+
+class Meta(BaseModel):
+    """Meta information on current page and collection"""
+
+    offset: int = Field(..., description="Current page offset")
+    total_items: int = Field(..., description="Total number of items in the collection")
+    total_pages: int = Field(..., description="Total number of pages in the collection")
+    page_number: int = Field(..., description="Current page number. Starts at 1.")
+
+
+class Page(Collection, Generic[T]):
+    """A page of the collection with info on current page and total items in meta."""
+
+    meta: Meta
+
+
+DbQuery = Union[LegacyQuery, Select]
+QueryCountDependency = Callable[..., int]
+PaginateSignature = Callable[[DbQuery, Optional[bool]], Page[T]]
+DefaultDependency = Callable[[Session, int, int], PaginateSignature]
+WithQueryCountDependency = Callable[[Session, int, int, int], PaginateSignature]
+PaginateDependency = Union[DefaultDependency, WithQueryCountDependency]
+
+
+def default_query_count(session: Session, query: DbQuery) -> int:
+    """Default function used to count items returned by a query.
+
+    It is slower than a manually written query could be: It runs the query in a
+    subquery, and count the number of elements returned.
+
+    See https://gist.github.com/hest/8798884
+    """
+    if isinstance(query, LegacyQuery):
+        result = query.count()
+
+    elif isinstance(query, Select):
+        result = session.execute(
+            select(func.count()).select_from(query.subquery())
+        ).scalar()
+
+    else:  # pragma no cover
+        raise NotImplementedError(f"Query type {type(query)!r} is not supported")
+
+    return result
+
+
+@singledispatch
+def paginate_query(
+    query: DbQuery,
+    session: Session,
+    total_items: int,
+    offset: int,
+    limit: int,
+    scalars: bool = True,
+) -> Page[T]:  # pragma no cover
+    "Dispatch on registered functions based on `query` type"
+    raise NotImplementedError(f"no paginate_query registered for type {type(query)!r}")
+
+
+@paginate_query.register
+def _paginate_legacy(
+    query: LegacyQuery,
+    session: Session,
+    total_items: int,
+    offset: int,
+    limit: int,
+    scalars: bool = True,
+) -> Page[T]:
+    total_pages = math.ceil(total_items / limit)
+    page_number = offset / limit + 1
+    return Page[T](
+        data=query.offset(offset).limit(limit).all(),
+        meta={
+            "offset": offset,
+            "total_items": total_items,
+            "total_pages": total_pages,
+            "page_number": page_number,
+        },
+    )
+
+
+@paginate_query.register
+def _paginate(
+    query: Select,
+    session: Session,
+    total_items: int,
+    offset: int,
+    limit: int,
+    *,
+    scalars: bool = True,
+) -> Page[T]:
+    total_pages = math.ceil(total_items / limit)
+    page_number = offset / limit + 1
+    query = query.offset(offset).limit(limit)
+    result = session.execute(query)
+    data = iter(result.unique().scalars() if scalars else result.mappings())
+    return Page[T](
+        data=data,
+        meta={
+            "offset": offset,
+            "total_items": total_items,
+            "total_pages": total_pages,
+            "page_number": page_number,
+        },
+    )
+
+
+def Pagination(
+    min_page_size: int = 10,
+    max_page_size: int = 100,
+    query_count: QueryCountDependency = None,
+) -> PaginateDependency:
+    def default_dependency(
+        session: Session = Depends(),
+        offset: int = Query(0, ge=0),
+        limit: int = Query(min_page_size, ge=1, le=max_page_size),
+    ) -> PaginateSignature:
+        def paginate(query: DbQuery, scalars=True) -> Page[T]:
+            total_items = default_query_count(session, query)
+            return paginate_query(
+                query, session, total_items, offset, limit, scalars=scalars
+            )
+
+        return paginate
+
+    def with_query_count_dependency(
+        session: Session = Depends(),
+        offset: int = Query(0, ge=0),
+        limit: int = Query(min_page_size, ge=1, le=max_page_size),
+        total_items: int = Depends(query_count),
+    ) -> PaginateSignature:
+        def paginate(query: DbQuery, scalars=True) -> Page[T]:
+            return paginate_query(
+                query, session, total_items, offset, limit, scalars=scalars
+            )
+
+        return paginate
+
+    if query_count:
+        return with_query_count_dependency
+    else:
+        return default_dependency
+
+
+Paginate: PaginateDependency = Pagination()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -85,6 +85,7 @@ def tear_down(environ):
 
     close_all_sessions()
     # reload fastapi_sqla to clear sqla deferred reflection mapping stored in Base
+    importlib.reload(fastapi_sqla.sqla)
     importlib.reload(fastapi_sqla)
 
 

--- a/tests/pagination/conftest.py
+++ b/tests/pagination/conftest.py
@@ -44,7 +44,7 @@ def setup_tear_down(sqla_connection, nb_users, nb_notes):
         metadata = MetaData()
         user = Table("user", metadata, autoload_with=sqla_connection)
         note = Table("note", metadata, autoload_with=sqla_connection)
-        user_params = [{"name": faker.name()}] * nb_users
+        user_params = [{"name": faker.name()} for i in range(0, nb_users)]
         note_params = [
             {"user_id": i % 42 + 1, "content": faker.text()} for i in range(0, nb_notes)
         ]

--- a/tests/test_asyncio_support.py
+++ b/tests/test_asyncio_support.py
@@ -7,17 +7,15 @@ pytestmark = [mark.sqlalchemy("1.4"), mark.require_asyncpg]
 
 
 @fixture
-async def setup(environ):
+async def startup(environ):
     from fastapi_sqla.asyncio_support import startup
 
     await startup()
     yield
 
 
-async def test_startup_configure_async_session():
-    from fastapi_sqla.asyncio_support import _AsyncSession, startup
-
-    await startup()
+async def test_startup_configure_async_session(startup):
+    from fastapi_sqla.asyncio_support import _AsyncSession
 
     async with _AsyncSession() as session:
         res = await session.execute(text("SELECT 123"))
@@ -25,7 +23,7 @@ async def test_startup_configure_async_session():
     assert res.scalar() == 123
 
 
-async def test_open_async_session(setup):
+async def test_open_async_session(startup):
     from fastapi_sqla.asyncio_support import open_session
 
     async with open_session() as session:

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -16,7 +16,7 @@ def setup_tear_down(engine):
 
 
 def test_startup_reflect_test_table():
-    from fastapi_sqla import Base, _Session, startup
+    from fastapi_sqla.sqla import Base, _Session, startup
 
     class TestTable(Base):
         __tablename__ = "test_table"
@@ -31,7 +31,7 @@ def test_startup_reflect_test_table():
 
 
 def test_startup_fails_when_table_doesnt_exist():
-    from fastapi_sqla import Base, startup
+    from fastapi_sqla.sqla import Base, startup
 
     class TestTable(Base):
         __tablename__ = "does_not_exist"

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -1,2 +1,11 @@
+from pytest import mark
+
+
 def test_import_fastapi_sqla():
     import fastapi_sqla  # noqa
+
+
+@mark.require_asyncpg
+@mark.sqlalchemy("1.4")
+def test_import_async_session():
+    from fastapi_sqla import AsyncSession  # noqa

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -166,7 +166,7 @@ async def test_commit_error_returns_500(client, user_1, mock_middleware):
 
 
 async def test_rollback_on_http_exception(client, mock_middleware):
-    with patch("fastapi_sqla.open_session") as open_session:
+    with patch("fastapi_sqla.sqla.open_session") as open_session:
         session = open_session.return_value.__enter__.return_value
 
         await client.get("/404")

--- a/tests/test_open_session.py
+++ b/tests/test_open_session.py
@@ -19,14 +19,14 @@ def module_setup_tear_down(engine, sqla_connection):
 
 @fixture(autouse=True)
 def setup(sqla_connection):
-    from fastapi_sqla import _Session
+    from fastapi_sqla.sqla import _Session
 
     _Session.configure(bind=sqla_connection)
 
 
 @fixture(scope="module")
 def TestTable(module_setup_tear_down):
-    from fastapi_sqla import Base, startup
+    from fastapi_sqla.sqla import Base, startup
 
     class TestTable(Base):
         __tablename__ = "test_table"

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -60,7 +60,7 @@ async def test_async_session_fixture_does_not_write_in_db(
 def test_sqla_14_all_opened_sessions_are_within_the_same_transaction(
     sqla_connection, session, singer_cls
 ):
-    from fastapi_sqla import _Session
+    from fastapi_sqla.sqla import _Session
 
     session.add(singer_cls(id=1, name="Bob Marley", country="Jamaica"))
     session.commit()
@@ -74,7 +74,7 @@ def test_sqla_14_all_opened_sessions_are_within_the_same_transaction(
 def test_sqla_13_all_opened_sessions_are_within_the_same_transaction(
     sqla_connection, session, singer_cls
 ):
-    from fastapi_sqla import _Session
+    from fastapi_sqla.sqla import _Session
 
     session.add(singer_cls(id=1, name="Bob Marley", country="Jamaica"))
     session.commit()

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -41,7 +41,7 @@ def boto_client_mock():
 
 @mark.dont_patch_engines
 def test_startup(case_sensitive_environ):
-    from fastapi_sqla import _Session, startup
+    from fastapi_sqla.sqla import _Session, startup
 
     startup()
 
@@ -52,7 +52,8 @@ def test_startup(case_sensitive_environ):
 
 @mark.dont_patch_engines
 async def test_fastapi_integration():
-    from fastapi_sqla import _Session, setup
+    from fastapi_sqla import setup
+    from fastapi_sqla.sqla import _Session
 
     app = FastAPI()
     setup(app)
@@ -75,7 +76,7 @@ async def test_fastapi_integration():
 
 @mark.dont_patch_engines
 def test_startup_fail_on_bad_sqlalchemy_url(monkeypatch):
-    from fastapi_sqla import startup
+    from fastapi_sqla.sqla import startup
 
     monkeypatch.setenv("sqlalchemy_url", "postgresql://postgres@localhost/notexisting")
 
@@ -100,7 +101,7 @@ async def test_async_startup_fail_on_bad_async_sqlalchemy_url(monkeypatch):
 def test_sync_startup_with_aws_rds_iam_enabled(
     monkeypatch, boto_session, boto_client_mock, db_host, db_user
 ):
-    from fastapi_sqla import startup
+    from fastapi_sqla.sqla import startup
 
     monkeypatch.setenv("fastapi_sqla_aws_rds_iam_enabled", "true")
 


### PR DESCRIPTION
## Description 

* As mentionned by @abnerjacobsen in #66 https://github.com/dialoguemd/fastapi-sqla/issues/66#issuecomment-1268960727, importing async components (`AsyncPaginate`, `AsyncPagination`, and `AsyncSession`) fails.
* This is due to circular imports: `fastapi_sqla.async_support` tried to import things in `fastapi_sqla` while being loaded.
* This PR moves most of the sync related API components in `fastapi_sqla.sqla` to avoid circular imports;

## Related JIRA issues

* [DIA-46202]

## Related PRs

<!-- * #123 -->
<!-- * dialoguemd/scribe#1234  -->



<!-- 📋 Checklist:
1. Follows [Commit Convention] and [Code Review guidelines]
   - example: feat(lang): add German language - DIA-12345
2. Relevant labels set
3. Draft PR for WIP
4. Requested from and notified to a team

[Commit Convention]: https://www.notion.so/godialogue/Commit-Convention-84fd9a4c149e48c998d760f1c9176df0
[Code Review guidelines]: https://www.notion.so/godialogue/Code-Review-c5f3fcd185ca49aca73ade497c398fe9  -->
