### PR TITLE
fix(ci): use python executor for the publish task - DIA-50447

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,11 +106,7 @@ jobs:
           codecov_flag: python_version<<parameters.python_version>>-sqlalchemy<<parameters.sqlalchemy_version>>-<<parameters.asyncpg>>-<<parameters.aws_rds_iam>>
 
   publish:
-    docker:
-    - image: cimg/python:latest
-      auth:
-        username: $DOCKERHUB_USER
-        password: $DOCKERHUB_ACCESS_TOKEN
+    executor: python
     working_directory: ~/project/.
     steps:
       - base/setup


### PR DESCRIPTION
## Description 

Update CI `publish` job to use the `python` executor. This should fix [this issue](https://app.circleci.com/pipelines/github/dialoguemd/fastapi-sqla/616/workflows/565cb811-f709-449e-812d-a00110e42cfd/jobs/4414).

## Related JIRA issues

* [DIA-50447]

## Related PRs

Follow up from https://github.com/dialoguemd/fastapi-sqla/pull/73


<!-- 📋 Checklist:
1. Follows [Commit Convention] and [Code Review guidelines]
   - example: feat(lang): add German language - DIA-12345
2. Relevant labels set
3. Draft PR for WIP
4. Requested from and notified to a team

[Commit Convention]: https://www.notion.so/godialogue/Commit-Convention-84fd9a4c149e48c998d760f1c9176df0
[Code Review guidelines]: https://www.notion.so/godialogue/Code-Review-c5f3fcd185ca49aca73ade497c398fe9  -->


[DIA-50447]: https://dialoguemd.atlassian.net/browse/DIA-50447?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ