### PR TITLE
chore: remove duplicate test - DIA-51295

### DIFF
--- a/tests/pagination/test_pagination.py
+++ b/tests/pagination/test_pagination.py
@@ -20,25 +20,6 @@ def test_pagination(
     assert result.meta.page_number == page_number
 
 
-@mark.sqlalchemy("1.3")
-@mark.parametrize(
-    "offset,limit,total_pages,page_number",
-    [(0, 5, 9, 1), (10, 10, 5, 2), (40, 10, 5, 5)],
-)
-def test_pagination_with_legacy_query_count(
-    session, user_cls, offset, limit, total_pages, page_number, nb_users
-):
-    from fastapi_sqla import Paginate
-
-    query = session.query(user_cls).options(joinedload(user_cls.notes))
-    result = Paginate(session, offset, limit)(query)
-
-    assert result.meta.total_items == nb_users
-    assert result.meta.offset == offset
-    assert result.meta.total_pages == total_pages
-    assert result.meta.page_number == page_number
-
-
 @mark.parametrize(
     "offset,items_number,path",
     [

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -57,7 +57,7 @@ async def test_async_session_fixture_does_not_write_in_db(
 
 
 @mark.sqlalchemy("1.4")
-def test_sqla_14_all_opened_sessions_are_within_the_same_transaction(
+def test_all_opened_sessions_are_within_the_same_transaction(
     sqla_connection, session, singer_cls
 ):
     from fastapi_sqla.sqla import _Session
@@ -70,7 +70,6 @@ def test_sqla_14_all_opened_sessions_are_within_the_same_transaction(
     assert other_session.get(singer_cls, 1)
 
 
-@mark.sqlalchemy("1.3")
 def test_sqla_13_all_opened_sessions_are_within_the_same_transaction(
     sqla_connection, session, singer_cls
 ):


### PR DESCRIPTION
## Description 

Why?

* Tests marked with `@mark.sqlalchemy("1.3")` will run when sqlalchemy version is `>1.3`, therefore, any `1.3` marker can be removed;

## Related

* #76 
* [DIA-51295]


[DIA-51295]: https://dialoguemd.atlassian.net/browse/DIA-51295?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ