### PR TITLE
chore: upgrade pytest to ^7.2.1

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -611,7 +611,7 @@ python-versions = "*"
 
 [[package]]
 name = "pytest"
-version = "7.2.0"
+version = "7.2.1"
 description = "pytest: simple powerful testing with Python"
 category = "main"
 optional = true
@@ -907,7 +907,7 @@ tests = ["alembic", "asgi_lifespan", "black", "Faker", "greenlet", "httpx", "iso
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "b6665195ab4bb90b4515722e7cb43e989b31ba6ea9e387bc2a076db5525c23b9"
+content-hash = "74685685ed8ae536aa72eacc2759fdbb5f6cd65eb0817f60d41aa26cda78d35a"
 
 [metadata.files]
 alembic = [
@@ -1359,8 +1359,8 @@ pyrepl = [
     {file = "pyrepl-0.9.0.tar.gz", hash = "sha256:292570f34b5502e871bbb966d639474f2b57fbfcd3373c2d6a2f3d56e681a775"},
 ]
 pytest = [
-    {file = "pytest-7.2.0-py3-none-any.whl", hash = "sha256:892f933d339f068883b6fd5a459f03d85bfcb355e4981e146d2c7616c21fef71"},
-    {file = "pytest-7.2.0.tar.gz", hash = "sha256:c4014eb40e10f11f355ad4e3c2fb2c6c6d1919c73f3b5a433de4708202cade59"},
+    {file = "pytest-7.2.1-py3-none-any.whl", hash = "sha256:c7c6ca206e93355074ae32f7403e8ea12163b1163c976fee7d4d84027c162be5"},
+    {file = "pytest-7.2.1.tar.gz", hash = "sha256:d45e0952f3727241918b8fd0f376f5ff6b301cc0777c6f9a556935c92d8a7d42"},
 ]
 pytest-asyncio = [
     {file = "pytest-asyncio-0.19.0.tar.gz", hash = "sha256:ac4ebf3b6207259750bc32f4c1d8fcd7e79739edbc67ad0c58dd150b1d072fed"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ isort = { version = "^5.5.3", optional = true}
 pdbpp = { version = "^0.10.2", optional = true}
 psycopg2 = { version = "^2.8.6", optional = true}
 pylama = {version = "^8.4.1", optional = true}
-pytest = {version = "^7.1.3", optional = true}
+pytest = {version = "^7.2.1", optional = true}
 pytest-asyncio = {version = "^0.19.0", optional = true}
 pytest-cov = { version = "^2.10.1", optional = true}
 tox = {version = "^3.26.0", optional = true}


### PR DESCRIPTION
## Description 

* Fix https://github.com/dialoguemd/fastapi-sqla/security/dependabot/5
