### PR TITLE
fix: table reflection with async db url - DIA-51295

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,75 @@
+import httpx
+from asgi_lifespan import LifespanManager
+from pydantic import BaseModel
+from pytest import fixture
+from sqlalchemy import text
+
+
+@fixture(scope="module", autouse=True)
+def setup_tear_down(engine):
+    with engine.connect() as connection:
+        with connection.begin():
+            connection.execute(
+                text(
+                    """
+                    CREATE TABLE IF NOT EXISTS public.user (
+                       id serial primary key,
+                       first_name varchar,
+                       last_name varchar
+                    )
+                    """
+                )
+            )
+            connection.execute(
+                text(
+                    """
+                    INSERT INTO public.user
+                    (first_name, last_name)
+                    VALUES
+                    ('Mulatu', 'Astatke'),
+                    ('Jimmy', 'Hughes'),
+                    ('Gill', 'Scott-Heron')
+                    """
+                )
+            )
+    yield
+    with engine.connect() as connection:
+        with connection.begin():
+            connection.execute(text("DROP TABLE public.user"))
+
+
+@fixture
+def sqla():
+    from fastapi_sqla import Base
+
+    class SQLA:
+        class User(Base):
+            __tablename__ = "user"
+
+    return SQLA
+
+
+@fixture
+def model():
+    class Model:
+        class UserIn(BaseModel):
+            first_name: str
+            last_name: str
+
+        class User(UserIn):
+            id: int
+
+            class Config:
+                orm_mode = True
+
+    return Model
+
+
+@fixture
+async def client(app):
+    async with LifespanManager(app):
+        transport = httpx.ASGITransport(app=app, raise_app_exceptions=False)
+        async with httpx.AsyncClient(
+            transport=transport, base_url="http://example.local"
+        ) as client:
+            yield client

--- a/tests/integration/test_async.py
+++ b/tests/integration/test_async.py
@@ -1,0 +1,83 @@
+from fastapi import Depends, FastAPI, HTTPException
+from pytest import fixture, mark
+from sqlalchemy import select
+
+pytestmark = [mark.sqlalchemy("1.4"), mark.require_asyncpg]
+
+
+@fixture
+def sqlalchemy_url(async_sqlalchemy_url):
+    return async_sqlalchemy_url
+
+
+@fixture(
+    autouse=True,
+    params=[["sqlalchemy_url"], ["sqlalchemy_url", "async_sqlalchemy_url"]],
+)
+def override_environ(
+    setup_tear_down, db_url, async_sqlalchemy_url, monkeypatch, request
+):
+    """Override environ to test the 2 cases.
+
+    In async mode, 2 environ are possible:
+    - db url is only defined in sqlalchemy_url envvar with async driver
+    - db url is defined twice:
+        * sqlalchemy_url with a sync driver;
+        * async_sqlalchemy_url with an async one;
+
+    This fixture allows testing in both case.
+    """
+    monkeypatch.delenv("sqlalchemy_url")
+    monkeypatch.delenv("async_sqlalchemy_url")
+
+    for fixture_name in request.param:
+        monkeypatch.setenv(fixture_name, request.getfixturevalue(fixture_name))
+
+
+@fixture
+def app(sqla, model):
+    from fastapi_sqla import AsyncPaginate, AsyncSession, Item, Page, setup
+
+    app = FastAPI()
+    setup(app)
+
+    @app.post("/users", response_model=Item[model.User], status_code=201)
+    async def create_user(user: model.UserIn, session: AsyncSession = Depends()):
+        new_user = sqla.User(**user.dict())
+        session.add(new_user)
+        await session.flush()
+        return {"data": new_user}
+
+    @app.get("/users/{id}", response_model=Item[model.User])
+    async def get_user(id: int, session: AsyncSession = Depends()):
+        user = await session.get(sqla.User, id)
+        if user is None:
+            raise HTTPException(404)
+        return {"data": user}
+
+    @app.get("/users", response_model=Page[model.User])
+    async def list_users(paginate: AsyncPaginate = Depends()):
+        return await paginate(select(sqla.User))
+
+    return app
+
+
+async def test_create_user(client, async_session, sqla):
+    res = await client.post(
+        "/users", json={"first_name": "Jacob", "last_name": "Miller"}
+    )
+    assert res.status_code == 201, (res.status_code, res.content)
+    data = res.json()["data"]
+    user = await async_session.get(sqla.User, data["id"])
+    assert user is not None
+
+
+async def test_get_user(client, async_session, sqla):
+    user = (await async_session.execute(select(sqla.User).limit(1))).scalar()
+    res = await client.get(f"/users/{user.id}")
+    assert res.status_code == 200, (res.status_code, res.content)
+
+
+async def test_list_users(client, async_session, sqla):
+    res = await client.get("/users")
+    assert res.status_code == 200, (res.status_code, res.content)


### PR DESCRIPTION
## Description 

* When using an async `sqlalchemy_url`, reflecting DB tables fail when using sqlalchemy 2.0;
* This PR fixes that issue.
* FYI it was not detected by tests but when I manually tried to upgrade fastapi-sqla version on an internal project;
* I've added integration tests with an async section to cover it;

### TODO:

- [ ] Reproduce in integration tests
- [ ] Fix it

## Related 

* [DIA-51295]


[DIA-51295]: https://dialoguemd.atlassian.net/browse/DIA-51295?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ