### PR TITLE
fix: table reflection with async db url - DIA-51295

### DIFF
--- a/fastapi_sqla/_pytest_plugin.py
+++ b/fastapi_sqla/_pytest_plugin.py
@@ -92,10 +92,9 @@ def sqla_modules():
 
 
 @fixture
-def sqla_reflection(sqla_modules, sqla_connection, db_url):
+def sqla_reflection(sqla_modules, sqla_connection):
     import fastapi_sqla
 
-    fastapi_sqla.Base.metadata.bind = sqla_connection
     fastapi_sqla.Base.prepare(sqla_connection.engine)
 
 
@@ -178,7 +177,15 @@ if asyncio_support:
                 yield new_engine
 
     @fixture
-    async def async_session(async_sqla_connection, sqla_reflection, patch_new_engine):
+    def async_sqla_reflection(sqla_modules, async_sqla_connection):
+        import fastapi_sqla
+
+        fastapi_sqla.Base.prepare(async_sqla_connection.engine.sync_engine)
+
+    @fixture
+    async def async_session(
+        async_sqla_connection, async_sqla_reflection, patch_new_engine
+    ):
         from fastapi_sqla.asyncio_support import _AsyncSession
 
         session = _AsyncSession(bind=async_sqla_connection)

--- a/fastapi_sqla/_pytest_plugin.py
+++ b/fastapi_sqla/_pytest_plugin.py
@@ -177,10 +177,12 @@ if asyncio_support:
                 yield new_engine
 
     @fixture
-    def async_sqla_reflection(sqla_modules, async_sqla_connection):
+    async def async_sqla_reflection(sqla_modules, async_sqla_connection):
         import fastapi_sqla
 
-        fastapi_sqla.Base.prepare(async_sqla_connection.engine.sync_engine)
+        await async_sqla_connection.run_sync(
+            lambda conn: fastapi_sqla.Base.prepare(conn.engine)
+        )
 
     @fixture
     async def async_session(

--- a/fastapi_sqla/_pytest_plugin.py
+++ b/fastapi_sqla/_pytest_plugin.py
@@ -93,9 +93,9 @@ def sqla_modules():
 
 @fixture
 def sqla_reflection(sqla_modules, sqla_connection):
-    import fastapi_sqla
+    from fastapi_sqla import Base
 
-    fastapi_sqla.Base.prepare(sqla_connection.engine)
+    Base.prepare(sqla_connection.engine)
 
 
 @fixture
@@ -178,11 +178,9 @@ if asyncio_support:
 
     @fixture
     async def async_sqla_reflection(sqla_modules, async_sqla_connection):
-        import fastapi_sqla
+        from fastapi_sqla import Base
 
-        await async_sqla_connection.run_sync(
-            lambda conn: fastapi_sqla.Base.prepare(conn.engine)
-        )
+        await async_sqla_connection.run_sync(lambda conn: Base.prepare(conn.engine))
 
     @fixture
     async def async_session(

--- a/fastapi_sqla/_pytest_plugin.py
+++ b/fastapi_sqla/_pytest_plugin.py
@@ -93,9 +93,9 @@ def sqla_modules():
 
 @fixture
 def sqla_reflection(sqla_modules, sqla_connection):
-    from fastapi_sqla import Base
+    import fastapi_sqla
 
-    Base.prepare(sqla_connection.engine)
+    fastapi_sqla.Base.prepare(sqla_connection.engine)
 
 
 @fixture

--- a/fastapi_sqla/asyncio_support.py
+++ b/fastapi_sqla/asyncio_support.py
@@ -36,18 +36,18 @@ async def startup():
     aws_rds_iam_support.setup(engine.sync_engine)
     aws_aurora_support.setup(engine.sync_engine)
 
-    # Fail early:
-    try:
-        async with engine.connect() as connection:
-            await connection.execute(text("select 'ok'"))
-    except Exception:
-        logger.critical(
-            "Failed querying db: is sqlalchemy_url or async_sqlalchemy_url envvar "
-            "correctly configured?"
-        )
-        raise
-
     async with engine.connect() as connection:
+        try:
+            # Fail early:
+            await connection.execute(text("select 'ok'"))
+        except Exception:
+            logger.critical(
+                "Failed querying db: is sqlalchemy_url or async_sqlalchemy_url envvar "
+                "correctly configured?"
+            )
+            raise
+
+        # Reflect tables
         await connection.run_sync(lambda conn: Base.prepare(conn.engine))
 
     _AsyncSession.configure(bind=engine, expire_on_commit=False)

--- a/fastapi_sqla/asyncio_support.py
+++ b/fastapi_sqla/asyncio_support.py
@@ -36,17 +36,18 @@ async def startup():
     aws_rds_iam_support.setup(engine.sync_engine)
     aws_aurora_support.setup(engine.sync_engine)
 
-    async with engine.connect() as connection:
-        try:
-            # Fail early:
+    # Fail early:
+    try:
+        async with engine.connect() as connection:
             await connection.execute(text("select 'ok'"))
-        except Exception:
-            logger.critical(
-                "Failed querying db: is sqlalchemy_url or async_sqlalchemy_url envvar "
-                "correctly configured?"
-            )
-            raise
+    except Exception:
+        logger.critical(
+            "Failed querying db: is sqlalchemy_url or async_sqlalchemy_url envvar "
+            "correctly configured?"
+        )
+        raise
 
+    async with engine.connect() as connection:
         # Reflect tables
         await connection.run_sync(lambda conn: Base.prepare(conn.engine))
 

--- a/fastapi_sqla/sqla.py
+++ b/fastapi_sqla/sqla.py
@@ -27,7 +27,7 @@ try:
 except ImportError:
     from sqlalchemy.ext.declarative import declarative_base
 
-    DeclarativeBase = declarative_base()
+    DeclarativeBase = declarative_base()  # type: ignore
 
 
 logger = structlog.get_logger(__name__)

--- a/fastapi_sqla/sqla.py
+++ b/fastapi_sqla/sqla.py
@@ -23,9 +23,11 @@ from sqlalchemy.sql import Select, func, select
 from fastapi_sqla import aws_aurora_support, aws_rds_iam_support
 
 try:
-    from sqlalchemy.orm import declarative_base
+    from sqlalchemy.orm import DeclarativeBase
 except ImportError:
     from sqlalchemy.ext.declarative import declarative_base
+
+    DeclarativeBase = declarative_base()
 
 
 logger = structlog.get_logger(__name__)
@@ -67,7 +69,7 @@ def startup():
     logger.info("startup", engine=engine)
 
 
-class Base(declarative_base(cls=DeferredReflection)):  # type: ignore
+class Base(DeferredReflection, DeclarativeBase):
     __abstract__ = True
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -80,8 +80,9 @@ def engine(environ):
 
 @fixture(autouse=True)
 def top_level_setup_tear_down(sqla_version_tuple):
-    import fastapi_sqla
     import sqlalchemy
+
+    import fastapi_sqla
     from fastapi_sqla import Base
 
     yield

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -83,7 +83,8 @@ def tear_down(environ):
     import fastapi_sqla
 
     yield
-
+    fastapi_sqla.Base.registry.dispose()
+    fastapi_sqla.Base.metadata.clear()
     close_all_sessions()
     # reload fastapi_sqla to clear sqla deferred reflection mapping stored in Base
     importlib.reload(fastapi_sqla.sqla)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -90,13 +90,12 @@ def top_level_setup_tear_down(sqla_version_tuple):
     close_all_sessions()
     Base.metadata.clear()
     importlib.reload(sqlalchemy)
-    if sqla_version_tuple <= (1, 4):
-        try:
-            importlib.reload(fastapi_sqla.asyncio_support)
-        except AttributeError:
-            pass
-        importlib.reload(fastapi_sqla.sqla)
-        importlib.reload(fastapi_sqla)
+    try:
+        importlib.reload(fastapi_sqla.asyncio_support)
+    except AttributeError:
+        pass
+    importlib.reload(fastapi_sqla.sqla)
+    importlib.reload(fastapi_sqla)
 
 
 @fixture

--- a/tests/db/versions/01_create_user_table_to_test.py
+++ b/tests/db/versions/01_create_user_table_to_test.py
@@ -17,11 +17,11 @@ depends_on = None
 
 def upgrade():
     op.create_table(
-        "testuser",
+        "test_db_migration_user",
         Column("id", Integer, primary_key=True, autoincrement=True),
         Column("name", String, nullable=False),
     )
 
 
 def downgrade():
-    op.drop_table("testuser")
+    op.drop_table("test_db_migration_user")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,75 @@
+import httpx
+from asgi_lifespan import LifespanManager
+from pydantic import BaseModel
+from pytest import fixture
+from sqlalchemy import text
+
+
+@fixture(scope="module", autouse=True)
+def setup_tear_down(engine):
+    with engine.connect() as connection:
+        with connection.begin():
+            connection.execute(
+                text(
+                    """
+                    CREATE TABLE IF NOT EXISTS test_integration_user (
+                       id serial primary key,
+                       first_name varchar,
+                       last_name varchar
+                    )
+                    """
+                )
+            )
+            connection.execute(
+                text(
+                    """
+                    INSERT INTO test_integration_user
+                    (first_name, last_name)
+                    VALUES
+                    ('Mulatu', 'Astatke'),
+                    ('Jimmy', 'Hughes'),
+                    ('Gill', 'Scott-Heron')
+                    """
+                )
+            )
+    yield
+    with engine.connect() as connection:
+        with connection.begin():
+            connection.execute(text("DROP TABLE test_integration_user"))
+
+
+@fixture
+def sqla():
+    from fastapi_sqla import Base
+
+    class SQLA:
+        class User(Base):
+            __tablename__ = "test_integration_user"
+
+    return SQLA
+
+
+@fixture
+def model():
+    class Model:
+        class UserIn(BaseModel):
+            first_name: str
+            last_name: str
+
+        class User(UserIn):
+            id: int
+
+            class Config:
+                orm_mode = True
+
+    return Model
+
+
+@fixture
+async def client(app):
+    async with LifespanManager(app):
+        transport = httpx.ASGITransport(app=app, raise_app_exceptions=False)
+        async with httpx.AsyncClient(
+            transport=transport, base_url="http://example.local"
+        ) as client:
+            yield client

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -6,7 +6,7 @@ from sqlalchemy import text
 
 
 @fixture(scope="module", autouse=True)
-def setup_tear_down(engine):
+def test_integration_module_setup_tear_down(engine):
     with engine.connect() as connection:
         with connection.begin():
             connection.execute(
@@ -73,3 +73,17 @@ async def client(app):
             transport=transport, base_url="http://example.local"
         ) as client:
             yield client
+
+
+@fixture
+def sqla_reflection():
+    # Overridden from _pytest_plugin conftest to assess reflection is done correctly by
+    # fastapi_sqla and not by plugin fixture sqla_reflection
+    pass
+
+
+@fixture
+def async_sqla_reflection():
+    # Overridden from _pytest_plugin conftest to assess reflection is done correctly by
+    # fastapi_sqla and not by plugin fixture async_sqla_reflection
+    pass

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -77,13 +77,13 @@ async def client(app):
 
 @fixture
 def sqla_reflection():
-    # Overridden from _pytest_plugin conftest to assess reflection is done correctly by
+    # Overridden from _pytest_plugin to assess reflection is done correctly by
     # fastapi_sqla and not by plugin fixture sqla_reflection
     pass
 
 
 @fixture
 def async_sqla_reflection():
-    # Overridden from _pytest_plugin conftest to assess reflection is done correctly by
+    # Overridden from _pytest_plugin to assess reflection is done correctly by
     # fastapi_sqla and not by plugin fixture async_sqla_reflection
     pass

--- a/tests/integration/test_async.py
+++ b/tests/integration/test_async.py
@@ -1,0 +1,80 @@
+from fastapi import Depends, FastAPI, HTTPException
+from pytest import fixture, mark
+from sqlalchemy import select
+
+pytestmark = [mark.sqlalchemy("1.4"), mark.require_asyncpg]
+
+
+@fixture(
+    autouse=True,
+    params=[
+        {"sqlalchemy_url": "async_sqlalchemy_url"},
+        {"sqlalchemy_url": "db_url", "async_sqlalchemy_url": "async_sqlalchemy_url"},
+    ],
+)
+def override_environ(setup_tear_down, async_sqlalchemy_url, monkeypatch, request):
+    """Override environ to test the 2 cases.
+
+    In async mode, 2 environ are possible:
+    - Only sqlalchemy_url envvar is defined with an async driver
+    - Both sqlalchemy_url and async_sqlalchemy_url are defined
+        * sqlalchemy_url with a sync driver;
+        * async_sqlalchemy_url with an async one;
+
+    This fixture allows testing in both case.
+    """
+    monkeypatch.delenv("sqlalchemy_url")
+    monkeypatch.delenv("async_sqlalchemy_url")
+    monkeypatch.setenv("sqlalchemy_url", async_sqlalchemy_url)
+
+    for envvar, fixture_name in request.param.items():
+        monkeypatch.setenv(envvar, request.getfixturevalue(fixture_name))
+
+
+@fixture
+def app(sqla, model):
+    from fastapi_sqla import AsyncPaginate, AsyncSession, Item, Page, setup
+
+    app = FastAPI()
+    setup(app)
+
+    @app.post("/users", response_model=Item[model.User], status_code=201)
+    async def create_user(user: model.UserIn, session: AsyncSession = Depends()):
+        new_user = sqla.User(**user.dict())
+        session.add(new_user)
+        await session.flush()
+        return {"data": new_user}
+
+    @app.get("/users/{id}", response_model=Item[model.User])
+    async def get_user(id: int, session: AsyncSession = Depends()):
+        user = await session.get(sqla.User, id)
+        if user is None:
+            raise HTTPException(404)
+        return {"data": user}
+
+    @app.get("/users", response_model=Page[model.User])
+    async def list_users(paginate: AsyncPaginate = Depends()):
+        return await paginate(select(sqla.User))
+
+    return app
+
+
+async def test_create_user(client, async_session, sqla):
+    res = await client.post(
+        "/users", json={"first_name": "Jacob", "last_name": "Miller"}
+    )
+    assert res.status_code == 201, (res.status_code, res.content)
+    data = res.json()["data"]
+    user = await async_session.get(sqla.User, data["id"])
+    assert user is not None
+
+
+async def test_get_user(client, async_session, sqla):
+    user = (await async_session.execute(select(sqla.User).limit(1))).scalar()
+    res = await client.get(f"/users/{user.id}")
+    assert res.status_code == 200, (res.status_code, res.content)
+
+
+async def test_list_users(client, async_session, sqla):
+    res = await client.get("/users")
+    assert res.status_code == 200, (res.status_code, res.content)

--- a/tests/integration/test_async.py
+++ b/tests/integration/test_async.py
@@ -12,7 +12,9 @@ pytestmark = [mark.sqlalchemy("1.4"), mark.require_asyncpg]
         {"sqlalchemy_url": "db_url", "async_sqlalchemy_url": "async_sqlalchemy_url"},
     ],
 )
-def override_environ(setup_tear_down, async_sqlalchemy_url, monkeypatch, request):
+def override_environ(
+    test_integration_module_setup_tear_down, async_sqlalchemy_url, monkeypatch, request
+):
     """Override environ to test the 2 cases.
 
     In async mode, 2 environ are possible:

--- a/tests/pagination/conftest.py
+++ b/tests/pagination/conftest.py
@@ -24,26 +24,26 @@ def setup_tear_down(sqla_connection, nb_users, nb_notes):
     with sqla_connection.begin():
         sqla_connection.execute(
             text(
-                "create table if not exists public.user "
+                "create table if not exists test_pagination_user "
                 "(id serial primary key, name varchar)"
             )
         )
         sqla_connection.execute(
             text(
                 """
-            create table if not exists note (
+            create table if not exists test_pagination_note (
                 user_id integer,
                 id serial,
                 content text,
                 primary key (user_id, id),
-                foreign key (user_id) references public.user (id)
+                foreign key (user_id) references test_pagination_user (id)
             )
             """
             )
         )
         metadata = MetaData()
-        user = Table("user", metadata, autoload_with=sqla_connection)
-        note = Table("note", metadata, autoload_with=sqla_connection)
+        user = Table("test_pagination_user", metadata, autoload_with=sqla_connection)
+        note = Table("test_pagination_note", metadata, autoload_with=sqla_connection)
         user_params = [{"name": faker.name()} for i in range(0, nb_users)]
         note_params = [
             {"user_id": i % 42 + 1, "content": faker.text()} for i in range(0, nb_notes)
@@ -52,8 +52,8 @@ def setup_tear_down(sqla_connection, nb_users, nb_notes):
         sqla_connection.execute(note.insert(), note_params)
     yield
     with sqla_connection.begin():
-        sqla_connection.execute(text("drop table note cascade"))
-        sqla_connection.execute(text("drop table public.user cascade"))
+        sqla_connection.execute(text("drop table test_pagination_note cascade"))
+        sqla_connection.execute(text("drop table test_pagination_user cascade"))
 
 
 @fixture
@@ -61,24 +61,24 @@ def sqla_modules(user_cls, note_cls):
     pass
 
 
-@fixture(scope="session")
+@fixture
 def user_cls(note_cls):
     from fastapi_sqla import Base
 
     class User(Base):
-        __tablename__ = "user"
+        __tablename__ = "test_pagination_user"
 
         notes = relationship("Note")
 
     return User
 
 
-@fixture(scope="session")
+@fixture
 def note_cls():
     from fastapi_sqla import Base
 
     class Note(Base):
-        __tablename__ = "note"
+        __tablename__ = "test_pagination_note"
 
     return Note
 

--- a/tests/pagination/conftest.py
+++ b/tests/pagination/conftest.py
@@ -19,7 +19,7 @@ def nb_notes(nb_users):
 
 
 @fixture(scope="module", autouse=True)
-def setup_tear_down(sqla_connection, nb_users, nb_notes):
+def test_pagination_module_setup_tear_down(sqla_connection, nb_users, nb_notes):
     faker = Faker(seed=0)
     with sqla_connection.begin():
         sqla_connection.execute(

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -3,7 +3,7 @@ from sqlalchemy import text
 
 
 @fixture(autouse=True, scope="module")
-def setup_tear_down(engine):
+def test_base_module_setup_tear_down(engine):
     with engine.connect() as connection:
         with connection.begin():
             connection.execute(

--- a/tests/test_db_migration.py
+++ b/tests/test_db_migration.py
@@ -10,4 +10,14 @@ def alembic_ini_path():
 
 
 def test_it(session):
-    session.execute(text("select * from testuser"))
+    session.execute(text("select * from test_db_migration_user"))
+
+
+@fixture
+def sqla_reflection():
+    pass
+
+
+@fixture
+def async_sqla_reflection():
+    pass

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -90,7 +90,7 @@ def mock_middleware(app: FastAPI):
 
 
 @fixture
-async def client(app):
+async def client(mock_middleware, app):
     async with LifespanManager(app):
         transport = httpx.ASGITransport(app=app, raise_app_exceptions=False)
         async with httpx.AsyncClient(

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -10,7 +10,7 @@ from structlog.testing import capture_logs
 
 
 @fixture(scope="module", autouse=True)
-def setup_tear_down(engine):
+def test_middleware_module_setup_tear_down(engine):
     with engine.connect() as connection:
         with connection.begin():
             connection.execute(
@@ -91,7 +91,6 @@ def mock_middleware(app: FastAPI):
 
 @fixture
 async def client(app):
-
     async with LifespanManager(app):
         transport = httpx.ASGITransport(app=app, raise_app_exceptions=False)
         async with httpx.AsyncClient(

--- a/tests/test_open_session.py
+++ b/tests/test_open_session.py
@@ -4,7 +4,7 @@ from sqlalchemy.exc import IntegrityError
 
 
 @fixture(autouse=True, scope="module")
-def module_setup_tear_down(engine, sqla_connection):
+def test_open_session_module_setup_tear_down(engine, sqla_connection):
     with sqla_connection.begin():
         sqla_connection.execute(
             text(
@@ -25,7 +25,7 @@ def setup(sqla_connection):
 
 
 @fixture
-def TestTable(module_setup_tear_down):
+def TestTable(test_open_session_module_setup_tear_down):
     from fastapi_sqla.sqla import Base, startup
 
     class TestTable(Base):

--- a/tests/test_open_session.py
+++ b/tests/test_open_session.py
@@ -24,7 +24,7 @@ def setup(sqla_connection):
     _Session.configure(bind=sqla_connection)
 
 
-@fixture(scope="module")
+@fixture
 def TestTable(module_setup_tear_down):
     from fastapi_sqla.sqla import Base, startup
 

--- a/tests/test_open_session.py
+++ b/tests/test_open_session.py
@@ -25,7 +25,7 @@ def setup(sqla_connection):
 
 
 @fixture
-def TestTable(test_open_session_module_setup_tear_down):
+def TestTable():
     from fastapi_sqla.sqla import Base, startup
 
     class TestTable(Base):

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -3,7 +3,7 @@ from sqlalchemy import text
 
 
 @fixture(scope="module", autouse=True)
-def setup_tear_down(sqla_connection):
+def test_pytest_plugin_module_setup_tear_down(sqla_connection):
     with sqla_connection.begin():
         sqla_connection.execute(
             text(

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -75,7 +75,7 @@ async def test_fastapi_integration():
 
 
 @mark.dont_patch_engines
-def test_startup_fail_on_bad_sqlalchemy_url(monkeypatch):
+def test_sqla_startup_fail_on_bad_sqlalchemy_url(monkeypatch):
     from fastapi_sqla.sqla import startup
 
     monkeypatch.setenv("sqlalchemy_url", "postgresql://postgres@localhost/notexisting")
@@ -86,12 +86,14 @@ def test_startup_fail_on_bad_sqlalchemy_url(monkeypatch):
 
 @mark.dont_patch_engines
 async def test_async_startup_fail_on_bad_async_sqlalchemy_url(monkeypatch):
+
+    from fastapi_sqla import asyncio_support
+
     monkeypatch.setenv(
         "async_sqlalchemy_url", "postgresql+asyncpg://postgres@localhost/notexisting"
     )
 
     with raises(Exception):
-        from fastapi_sqla import asyncio_support
 
         await asyncio_support.startup()
 

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -85,6 +85,8 @@ def test_sqla_startup_fail_on_bad_sqlalchemy_url(monkeypatch):
 
 
 @mark.dont_patch_engines
+@mark.require_asyncpg
+@mark.sqlalchemy("1.4")
 async def test_async_startup_fail_on_bad_async_sqlalchemy_url(monkeypatch):
 
     from fastapi_sqla import asyncio_support

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -75,7 +75,7 @@ async def test_fastapi_integration():
 
 
 @mark.dont_patch_engines
-def test_sqla_startup_fail_on_bad_sqlalchemy_url(monkeypatch):
+def test_startup_fail_on_bad_sqlalchemy_url(monkeypatch):
     from fastapi_sqla.sqla import startup
 
     monkeypatch.setenv("sqlalchemy_url", "postgresql://postgres@localhost/notexisting")
@@ -85,17 +85,13 @@ def test_sqla_startup_fail_on_bad_sqlalchemy_url(monkeypatch):
 
 
 @mark.dont_patch_engines
-@mark.require_asyncpg
-@mark.sqlalchemy("1.4")
 async def test_async_startup_fail_on_bad_async_sqlalchemy_url(monkeypatch):
-
-    from fastapi_sqla import asyncio_support
-
     monkeypatch.setenv(
         "async_sqlalchemy_url", "postgresql+asyncpg://postgres@localhost/notexisting"
     )
 
     with raises(Exception):
+        from fastapi_sqla import asyncio_support
 
         await asyncio_support.startup()
 
@@ -126,7 +122,7 @@ async def test_async_startup_with_aws_rds_iam_enabled(
     from fastapi_sqla.asyncio_support import startup
 
     monkeypatch.setenv("fastapi_sqla_aws_rds_iam_enabled", "true")
-    monkeypatch.setenv("sqlalchemy_url", async_sqlalchemy_url)
+    monkeypatch.setenv("async_sqlalchemy_url", async_sqlalchemy_url)
 
     await startup()
 

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -122,10 +122,10 @@ async def test_async_startup_with_aws_rds_iam_enabled(
     from fastapi_sqla.asyncio_support import startup
 
     monkeypatch.setenv("fastapi_sqla_aws_rds_iam_enabled", "true")
-    monkeypatch.setenv("async_sqlalchemy_url", async_sqlalchemy_url)
+    monkeypatch.setenv("sqlalchemy_url", async_sqlalchemy_url)
 
     await startup()
 
-    boto_client_mock.generate_db_auth_token.assert_called_once_with(
+    boto_client_mock.generate_db_auth_token.assert_called_with(
         DBHostname=db_host, Port=5432, DBUsername=db_user
     )


### PR DESCRIPTION
## Description 

* Table reflection does not work when using async sqlalchemy configuration with `sqlalchemy>=2.0.0`;
* It was not discovered by tests: I noticed it when trying to upgrade a project to `fastapi-sqla=2.8.0` and   `sqlalchemy>=2.0.0`;
* It worked in tests because the fixture `async_session` depended on `sqla_reflection` which would run reflection in synchronous mode; Any subsequent call to `Base.prepare` to do reflection would do nothing as reflection already occurred in test setup;
* Added a `async_sqla_reflection` fixture to make async tests fail;
* Added an integration folder in tests and added a set of test in async mode; Will continue in other PRs to reorganize tests;
* Updated tearing down configured sqla mappers & metadata in tests;
* Renamed tables created in test to ease troubleshooting;

### TODO:

* [x] Reproduce bug in test
* [x] Fix it

## Related

* #76 
* [DIA-51295]


[DIA-51295]: https://dialoguemd.atlassian.net/browse/DIA-51295?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ