### PR TITLE
fix: table reflection with async db url - DIA-51295

### DIFF
--- a/fastapi_sqla/_pytest_plugin.py
+++ b/fastapi_sqla/_pytest_plugin.py
@@ -178,7 +178,15 @@ if asyncio_support:
                 yield new_engine
 
     @fixture
-    async def async_session(async_sqla_connection, sqla_reflection, patch_new_engine):
+    async def async_sqla_reflection(sqla_modules, async_sqla_connection):
+        from fastapi_sqla import Base
+
+        await async_sqla_connection.run_sync(lambda conn: Base.prepare(conn.engine))
+
+    @fixture
+    async def async_session(
+        async_sqla_connection, async_sqla_reflection, patch_new_engine
+    ):
         from fastapi_sqla.asyncio_support import _AsyncSession
 
         session = _AsyncSession(bind=async_sqla_connection)

--- a/fastapi_sqla/asyncio_support.py
+++ b/fastapi_sqla/asyncio_support.py
@@ -45,7 +45,9 @@ async def startup():
         )
         raise
 
-    Base.prepare(engine.engine)
+    async with engine.connect() as connection:
+        await connection.run_sync(lambda conn: Base.prepare(conn.engine))
+
     _AsyncSession.configure(bind=engine, expire_on_commit=False)
     logger.info("startup", async_engine=engine)
 

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -89,7 +89,7 @@ def mock_middleware(app: FastAPI):
 
 
 @fixture
-async def client(app):
+async def client(app, mock_middleware):
 
     async with LifespanManager(app):
         transport = httpx.ASGITransport(app=app, raise_app_exceptions=False)

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -126,6 +126,6 @@ async def test_async_startup_with_aws_rds_iam_enabled(
 
     await startup()
 
-    boto_client_mock.generate_db_auth_token.assert_called_once_with(
+    boto_client_mock.generate_db_auth_token.assert_called_with(
         DBHostname=db_host, Port=5432, DBUsername=db_user
     )


### PR DESCRIPTION
## Description 

* Table reflection does not work when using async sqlalchemy configuration with sqlalchemy>=2.0.0;
* It was not discovered by tests: I noticed it when trying to upgrade a project to fastapi-sqla=2.8.0 and sqlalchemy>=2.0.0;
* It worked in tests because the fixture async_session depended on sqla_reflection which would run reflection in synchronous mode; Any subsequent call to Base.prepare to do reflection would do nothing as reflection already occurred in test setup;
* Updated `asyncio_support` startup & added a async_sqla_reflection fixture to make async tests fail;

I want to reorganize tests and introduce real integration tests. Doing it in current PR would make it too big IMO;

## Related

* [DIA-51295]
* #76
* Closed #81 in favor of current PR.




<!-- 📋 Checklist:
1. Follows [Commit Convention] and [Code Review guidelines]
   - example: feat(lang): add German language - DIA-12345
2. Relevant labels set
3. Draft PR for WIP
4. Requested from and notified to a team

[Commit Convention]: https://www.notion.so/godialogue/Commit-Convention-84fd9a4c149e48c998d760f1c9176df0
[Code Review guidelines]: https://www.notion.so/godialogue/Code-Review-c5f3fcd185ca49aca73ade497c398fe9  -->


[DIA-51295]: https://dialoguemd.atlassian.net/browse/DIA-51295?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ