### PR TITLE
feat: add support for overloading Base class (proposal)

### DIFF
--- a/fastapi_sqla/__init__.py
+++ b/fastapi_sqla/__init__.py
@@ -52,7 +52,7 @@ except ImportError as err:
     asyncio_support_err = str(err)
 
 
-def setup(app: FastAPI, base_cls: Union[type, None] = None):
+def setup(app: FastAPI, *, base_cls: Union[type, None] = None):
     engine = sqla.new_engine()
 
     if not sqla.is_async_dialect(engine):

--- a/fastapi_sqla/asyncio_support.py
+++ b/fastapi_sqla/asyncio_support.py
@@ -29,7 +29,7 @@ def new_async_engine():
     return AsyncEngine(engine)
 
 
-async def startup(base_cls: Union[type, None] = None):
+async def startup(*, base_cls: Union[type, None] = None):
     engine = new_async_engine()
     aws_rds_iam_support.setup(engine.sync_engine)
     aws_aurora_support.setup(engine.sync_engine)

--- a/fastapi_sqla/asyncio_support.py
+++ b/fastapi_sqla/asyncio_support.py
@@ -29,7 +29,7 @@ def new_async_engine():
     return AsyncEngine(engine)
 
 
-async def startup():
+async def startup(base_cls: Union[type, None] = None):
     engine = new_async_engine()
     aws_rds_iam_support.setup(engine.sync_engine)
     aws_aurora_support.setup(engine.sync_engine)
@@ -46,6 +46,8 @@ async def startup():
         raise
 
     async with engine.connect() as connection:
+        if base_cls is None:
+            base_cls = Base
         await connection.run_sync(lambda conn: Base.prepare(conn.engine))
 
     _AsyncSession.configure(bind=engine, expire_on_commit=False)

--- a/fastapi_sqla/asyncio_support.py
+++ b/fastapi_sqla/asyncio_support.py
@@ -48,7 +48,9 @@ async def startup(*, base_cls: Union[type, None] = None):
     async with engine.connect() as connection:
         if base_cls is None:
             base_cls = Base
-        await connection.run_sync(lambda conn: Base.prepare(conn.engine))
+        await connection.run_sync(
+            lambda conn: base_cls.prepare(conn.engine) # type: ignore
+        )
 
     _AsyncSession.configure(bind=engine, expire_on_commit=False)
     logger.info("startup", async_engine=engine)

--- a/fastapi_sqla/sqla.py
+++ b/fastapi_sqla/sqla.py
@@ -47,7 +47,7 @@ def is_async_dialect(engine):
     return engine.dialect.is_async if hasattr(engine.dialect, "is_async") else False
 
 
-def startup(base_cls: Union[type, None] = None):
+def startup(*, base_cls: Union[type, None] = None):
     engine = new_engine()
     aws_rds_iam_support.setup(engine.engine)
     aws_aurora_support.setup(engine.engine)

--- a/fastapi_sqla/sqla.py
+++ b/fastapi_sqla/sqla.py
@@ -47,7 +47,7 @@ def is_async_dialect(engine):
     return engine.dialect.is_async if hasattr(engine.dialect, "is_async") else False
 
 
-def startup():
+def startup(base_cls: Union[type, None] = None):
     engine = new_engine()
     aws_rds_iam_support.setup(engine.engine)
     aws_aurora_support.setup(engine.engine)
@@ -62,7 +62,10 @@ def startup():
         )
         raise
 
-    Base.prepare(engine)
+    if base_cls is None:
+        base_cls = Base
+
+    base_cls.prepare(engine) # type: ignore
     _Session.configure(bind=engine)
     logger.info("startup", engine=engine)
 


### PR DESCRIPTION
## Description 

FastAPI-sqla currently enforces we use the provided `Base` class, such as preventing consumers from using non-reflected base classes (such as the new SQLA2 `DeclarativeBase` class).

This proposal adds the ability to pass in a custom `base_cls` to the `fastapi_sqla.setup()` function, in order to allow more flexibility.

e.g.
```py
# --------------------my_app/sqla.py------------------- #
from sqlalchemy.orm import DeclarativeBase

class Base(DeclarativeBase):
  __abstract__ = True


# --------------------my_app/main.py------------------- #
from fastapi_sqla import setup()

from my_app.sqla import Base

app = FastAPI()

setup(app, base_cls=Base)
```

If this proposal sounds acceptable, then I'll work on writing documentation on the matter inc. updating the pytest plugin to support (or document how to support) passing in a custom base.

Note: tests fail due to assertion that's a little strict on `app.add_event_handler` being called, but this should be fully backwards compatible.
