### PR TITLE
fix: move models to their own modules - DIA-61984

### DIFF
--- a/fastapi_sqla/__init__.py
+++ b/fastapi_sqla/__init__.py
@@ -3,11 +3,9 @@ import os
 from fastapi import FastAPI
 
 from fastapi_sqla import sqla
+from fastapi_sqla.models import Collection, Item, Page
 from fastapi_sqla.sqla import (
     Base,
-    Collection,
-    Item,
-    Page,
     Paginate,
     PaginateSignature,
     Pagination,

--- a/fastapi_sqla/models.py
+++ b/fastapi_sqla/models.py
@@ -34,7 +34,7 @@ class Meta(BaseModel):
     page_number: int = Field(..., description="Current page number. Starts at 1.")
 
 
-class Page(Collection, Generic[T]):
+class Page(Collection[T], Generic[T]):
     """A page of the collection with info on current page and total items in meta."""
 
     meta: Meta

--- a/fastapi_sqla/models.py
+++ b/fastapi_sqla/models.py
@@ -1,0 +1,40 @@
+from typing import Generic, TypeVar
+
+from pydantic import BaseModel, Field
+from pydantic import __version__ as pydantic_version
+
+major, _, _ = [int(v) for v in pydantic_version.split(".")]
+is_pydantic2 = major == 2
+if is_pydantic2:
+    GenericModel = BaseModel
+else:
+    from pydantic.generics import GenericModel  # type:ignore
+
+T = TypeVar("T")
+
+
+class Item(GenericModel, Generic[T]):
+    """Item container."""
+
+    data: T
+
+
+class Collection(GenericModel, Generic[T]):
+    """Collection container."""
+
+    data: list[T]
+
+
+class Meta(BaseModel):
+    """Meta information on current page and collection"""
+
+    offset: int = Field(..., description="Current page offset")
+    total_items: int = Field(..., description="Total number of items in the collection")
+    total_pages: int = Field(..., description="Total number of pages in the collection")
+    page_number: int = Field(..., description="Current page number. Starts at 1.")
+
+
+class Page(Collection, Generic[T]):
+    """A page of the collection with info on current page and total items in meta."""
+
+    meta: Meta


### PR DESCRIPTION
## Description 

Move models to their own module to have better separation of concerns. This change shouldn't cause any issue since we expect people to include the models from the root module like `from fastapi_sqla import Item`.

## Related JIRA issues

* [DIA-61984]

## Validation

All tests still pass ✅ 

<!-- 📋 Checklist:
1. Title follows [Commit Convention] and [Code Review guidelines]
   - example: feat(lang): add German language - DIA-12345
2. Relevant labels set
3. Draft PR for WIP
4. Validation notes added
5. Requested from and notified to a team

[Commit Convention]: https://www.notion.so/godialogue/Commit-Convention-84fd9a4c149e48c998d760f1c9176df0
[Code Review guidelines]: https://www.notion.so/godialogue/Code-Review-c5f3fcd185ca49aca73ade497c398fe9  -->


[DIA-61984]: https://dialoguemd.atlassian.net/browse/DIA-61984?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ