### PR TITLE
fix: pytest plugin event-loop deprecation warning

### DIFF
--- a/fastapi_sqla/_pytest_plugin.py
+++ b/fastapi_sqla/_pytest_plugin.py
@@ -160,7 +160,7 @@ if asyncio_support:  # noqa: C901
         return create_async_engine(async_sqlalchemy_url)
 
     @fixture
-    async def async_sqla_connection(async_engine, event_loop):
+    async def async_sqla_connection(async_engine):
         async with async_engine.connect() as connection:
             yield connection
 


### PR DESCRIPTION
## Description 

Removes dependency on `event_loop` fixture in `async_sqla_connection` pytest plugin fixture, which silences following warning getting logged when running tests on projects which use fastapi-sqla.

```
.venv/lib/python3.11/site-packages/pytest_asyncio/plugin.py:231: 
PytestDeprecationWarning: async_sqla_connection is asynchronous 
and explicitly requests the "event_loop" fixture. Asynchronous 
fixtures and test functions should use "asyncio.get_running_loop()" 
instead.
```



