### PR TITLE
feat: use pure ASGI middlewares

### DIFF
--- a/fastapi_sqla/async_sqla.py
+++ b/fastapi_sqla/async_sqla.py
@@ -9,6 +9,7 @@ from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncEngine
 from sqlalchemy.ext.asyncio import AsyncSession as SqlaAsyncSession
 from sqlalchemy.orm.session import sessionmaker
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 from fastapi_sqla import aws_aurora_support, aws_rds_iam_support
 from fastapi_sqla.sqla import _DEFAULT_SESSION_KEY, Base, new_engine
@@ -88,9 +89,7 @@ async def open_session(
         await session.close()
 
 
-async def add_session_to_request(
-    request: Request, call_next, key: str = _DEFAULT_SESSION_KEY
-):
+class AsyncSessionMiddleware:
     """Middleware which injects a new sqla async session into every request.
 
     Handles creation of session, as well as commit, rollback, and closing of session.
@@ -108,36 +107,58 @@ async def add_session_to_request(
         async def get_users(session: fastapi_sqla.AsyncSession):
             return await session.execute(...) # use your session here
     """
-    async with open_session(key) as session:
-        setattr(request.state, f"{_ASYNC_REQUEST_SESSION_KEY}_{key}", session)
-        response = await call_next(request)
+    def __init__(self, app: ASGIApp, key: str = _DEFAULT_SESSION_KEY) -> None:
+        self.app = app
+        self.key = key
 
-        is_dirty = bool(session.dirty or session.deleted or session.new)
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            return await self.app(scope, receive, send)
 
-        # try to commit after response, so that we can return a proper 500 response
-        # and not raise a true internal server error
-        if response.status_code < 400:
-            try:
-                await session.commit()
-            except Exception:
-                logger.exception("commit failed, returning http error")
-                response = PlainTextResponse(
-                    content="Internal Server Error", status_code=500
-                )
+        async with open_session(self.key) as session:
+            request = Request(scope=scope, receive=receive, send=send)
+            setattr(request.state, f"{_ASYNC_REQUEST_SESSION_KEY}_{self.key}", session)
 
-        if response.status_code >= 400:
-            # If ever a route handler returns an http exception, we do not want the
-            # session opened by current context manager to commit anything in db.
-            if is_dirty:
-                # optimistically only log if there were uncommitted changes
-                logger.warning(
-                    "http error, rolling back possibly uncommitted changes",
-                    status_code=response.status_code,
-                )
-            # since this is no-op if session is not dirty, we can always call it
-            await session.rollback()
+            async def send_wrapper(message: Message) -> None:
+                if message["type"] == "http.response.start":
+                    has_responded = False
+                    status_code = message["status"]
 
-    return response
+                    is_dirty = bool(session.dirty or session.deleted or session.new)
+
+                    # try to commit after response, so that we can return a proper 500
+                    # and not raise a true internal server error
+                    if status_code < 400:
+                        try:
+                            await session.commit()
+                        except Exception:
+                            logger.exception("commit failed, returning http error")
+                            status_code = 500
+                            response = PlainTextResponse(
+                                content="Internal Server Error", status_code=500
+                            )
+                            await response(scope, receive, send)
+                            has_responded = True
+
+                    if status_code >= 400:
+                        # If ever a route handler returns an http exception,
+                        # we do not want the current session to commit anything in db.
+                        if is_dirty:
+                            # optimistically only log if there were uncommitted changes
+                            logger.warning(
+                                "http error, rolling back possibly uncommitted changes",
+                                status_code=status_code,
+                            )
+                        # since this is no-op if the session is not dirty,
+                        # we can always call it
+                        await session.rollback()
+
+                    if has_responded:
+                        return
+
+                await send(message)
+
+            await self.app(scope, receive, send_wrapper)
 
 
 class AsyncSessionDependency:

--- a/fastapi_sqla/async_sqla.py
+++ b/fastapi_sqla/async_sqla.py
@@ -107,6 +107,7 @@ class AsyncSessionMiddleware:
         async def get_users(session: fastapi_sqla.AsyncSession):
             return await session.execute(...) # use your session here
     """
+
     def __init__(self, app: ASGIApp, key: str = _DEFAULT_SESSION_KEY) -> None:
         self.app = app
         self.key = key

--- a/fastapi_sqla/base.py
+++ b/fastapi_sqla/base.py
@@ -36,9 +36,7 @@ def setup_middlewares(app: FastAPI):
     engines = {key: sqla.new_engine(key) for key in engine_keys}
     for key, engine in engines.items():
         if not _is_async_dialect(engine):
-            app.middleware("http")(
-                functools.partial(sqla.add_session_to_request, key=key)
-            )
+            app.add_middleware(sqla.SessionMiddleware, key=key)
         else:
             app.middleware("http")(
                 functools.partial(async_sqla.add_session_to_request, key=key)
@@ -54,9 +52,7 @@ def setup(app: FastAPI):
     for key, engine in engines.items():
         if not _is_async_dialect(engine):
             app.add_event_handler("startup", functools.partial(sqla.startup, key=key))
-            app.middleware("http")(
-                functools.partial(sqla.add_session_to_request, key=key)
-            )
+            app.add_middleware(sqla.SessionMiddleware, key=key)
         else:
             app.add_event_handler(
                 "startup", functools.partial(async_sqla.startup, key=key)

--- a/fastapi_sqla/base.py
+++ b/fastapi_sqla/base.py
@@ -38,9 +38,7 @@ def setup_middlewares(app: FastAPI):
         if not _is_async_dialect(engine):
             app.add_middleware(sqla.SessionMiddleware, key=key)
         else:
-            app.middleware("http")(
-                functools.partial(async_sqla.add_session_to_request, key=key)
-            )
+            app.add_middleware(async_sqla.AsyncSessionMiddleware, key=key)
 
 
 @deprecated(
@@ -57,9 +55,7 @@ def setup(app: FastAPI):
             app.add_event_handler(
                 "startup", functools.partial(async_sqla.startup, key=key)
             )
-            app.middleware("http")(
-                functools.partial(async_sqla.add_session_to_request, key=key)
-            )
+            app.add_middleware(async_sqla.AsyncSessionMiddleware, key=key)
 
 
 def _get_engine_keys() -> set[str]:

--- a/fastapi_sqla/sqla.py
+++ b/fastapi_sqla/sqla.py
@@ -138,8 +138,6 @@ class SessionMiddleware:
         if scope["type"] != "http":
             return await self.app(scope, receive, send)
 
-        logger.debug(f"executing fastapi-sqla middleware - {self.key}")
-
         async with contextmanager_in_threadpool(open_session(self.key)) as session:
             request = Request(scope=scope, receive=receive, send=send)
             setattr(request.state, f"{_REQUEST_SESSION_KEY}_{self.key}", session)

--- a/fastapi_sqla/sqla.py
+++ b/fastapi_sqla/sqla.py
@@ -129,6 +129,7 @@ class SessionMiddleware:
         def get_users(session: fastapi_sqla.Session):
             return session.execute(...) # use your session here
     """
+
     def __init__(self, app: ASGIApp, key: str = _DEFAULT_SESSION_KEY) -> None:
         self.app = app
         self.key = key

--- a/tests/test_base_setup_middlewares.py
+++ b/tests/test_base_setup_middlewares.py
@@ -79,8 +79,5 @@ def test_setup_middlewares_with_async_default_sqlalchemy_url(async_sqlalchemy_ur
         setup_middlewares(app)
 
     app.add_middleware.assert_called_once()
-    assert (
-        app.add_middleware.call_args.args[0]
-        == async_sqla.AsyncSessionMiddleware
-    )
+    assert app.add_middleware.call_args.args[0] == async_sqla.AsyncSessionMiddleware
     assert app.add_middleware.call_args.kwargs["key"] == _DEFAULT_SESSION_KEY

--- a/tests/test_base_setup_middlewares.py
+++ b/tests/test_base_setup_middlewares.py
@@ -22,21 +22,23 @@ def test_setup_middlewares_multiple_engines(db_url):
     ):
         setup_middlewares(app)
 
-    assert app.middleware.call_count == 2
-    assert all(call.args[0] == "http" for call in app.middleware.call_args_list)
+    assert app.add_middleware.call_count == 2
+    assert all(
+        call.args[0] == sqla.SessionMiddleware
+        for call in app.add_middleware.call_args_list
+    )
 
-    assert app.middleware.return_value.call_count == 2
     assert any(
         call
-        for call in app.middleware.return_value.call_args_list
-        if call.args[0].func == sqla.add_session_to_request
-        and call.args[0].keywords == {"key": _DEFAULT_SESSION_KEY}
+        for call in app.add_middleware.call_args_list
+        if call.args[0] == sqla.SessionMiddleware
+        and call.kwargs["key"] == _DEFAULT_SESSION_KEY
     )
     assert any(
         call
-        for call in app.middleware.return_value.call_args_list
-        if call.args[0].func == sqla.add_session_to_request
-        and call.args[0].keywords == {"key": read_only_key}
+        for call in app.add_middleware.call_args_list
+        if call.args[0] == sqla.SessionMiddleware
+        and call.kwargs["key"] == read_only_key
     )
 
 
@@ -49,21 +51,18 @@ def test_setup_middlewares_with_sync_and_async_sqlalchemy_url(async_session_key)
     app = Mock()
     setup_middlewares(app)
 
-    assert app.middleware.call_count == 2
-    assert all(call.args[0] == "http" for call in app.middleware.call_args_list)
-
-    assert app.middleware.return_value.call_count == 2
+    assert app.add_middleware.call_count == 2
     assert any(
         call
-        for call in app.middleware.return_value.call_args_list
-        if call.args[0].func == sqla.add_session_to_request
-        and call.args[0].keywords == {"key": _DEFAULT_SESSION_KEY}
+        for call in app.add_middleware.call_args_list
+        if call.args[0] == sqla.SessionMiddleware
+        and call.kwargs["key"] == _DEFAULT_SESSION_KEY
     )
     assert any(
         call
-        for call in app.middleware.return_value.call_args_list
-        if call.args[0].func == async_sqla.add_session_to_request
-        and call.args[0].keywords == {"key": async_session_key}
+        for call in app.add_middleware.call_args_list
+        if call.args[0] == async_sqla.AsyncSessionMiddleware
+        and call.kwargs["key"] == async_session_key
     )
 
 
@@ -79,12 +78,9 @@ def test_setup_middlewares_with_async_default_sqlalchemy_url(async_sqlalchemy_ur
     ):
         setup_middlewares(app)
 
-    app.middleware.assert_called_once_with("http")
-    app.middleware.return_value.assert_called_once()
+    app.add_middleware.assert_called_once()
     assert (
-        app.middleware.return_value.call_args.args[0].func
-        == async_sqla.add_session_to_request
+        app.add_middleware.call_args.args[0]
+        == async_sqla.AsyncSessionMiddleware
     )
-    assert app.middleware.return_value.call_args.args[0].keywords == {
-        "key": _DEFAULT_SESSION_KEY
-    }
+    assert app.add_middleware.call_args.kwargs["key"] == _DEFAULT_SESSION_KEY

--- a/tests/test_base_setup_middlewares.py
+++ b/tests/test_base_setup_middlewares.py
@@ -28,18 +28,8 @@ def test_setup_middlewares_multiple_engines(db_url):
         for call in app.add_middleware.call_args_list
     )
 
-    assert any(
-        call
-        for call in app.add_middleware.call_args_list
-        if call.args[0] == sqla.SessionMiddleware
-        and call.kwargs["key"] == _DEFAULT_SESSION_KEY
-    )
-    assert any(
-        call
-        for call in app.add_middleware.call_args_list
-        if call.args[0] == sqla.SessionMiddleware
-        and call.kwargs["key"] == read_only_key
-    )
+    app.add_middleware.assert_any_call(sqla.SessionMiddleware, key=_DEFAULT_SESSION_KEY)
+    app.add_middleware.assert_any_call(sqla.SessionMiddleware, key=read_only_key)
 
 
 @mark.sqlalchemy("1.4")
@@ -52,17 +42,9 @@ def test_setup_middlewares_with_sync_and_async_sqlalchemy_url(async_session_key)
     setup_middlewares(app)
 
     assert app.add_middleware.call_count == 2
-    assert any(
-        call
-        for call in app.add_middleware.call_args_list
-        if call.args[0] == sqla.SessionMiddleware
-        and call.kwargs["key"] == _DEFAULT_SESSION_KEY
-    )
-    assert any(
-        call
-        for call in app.add_middleware.call_args_list
-        if call.args[0] == async_sqla.AsyncSessionMiddleware
-        and call.kwargs["key"] == async_session_key
+    app.add_middleware.assert_any_call(sqla.SessionMiddleware, key=_DEFAULT_SESSION_KEY)
+    app.add_middleware.assert_any_call(
+        async_sqla.AsyncSessionMiddleware, key=async_session_key
     )
 
 
@@ -78,6 +60,6 @@ def test_setup_middlewares_with_async_default_sqlalchemy_url(async_sqlalchemy_ur
     ):
         setup_middlewares(app)
 
-    app.add_middleware.assert_called_once()
-    assert app.add_middleware.call_args.args[0] == async_sqla.AsyncSessionMiddleware
-    assert app.add_middleware.call_args.kwargs["key"] == _DEFAULT_SESSION_KEY
+    app.add_middleware.assert_called_once_with(
+        async_sqla.AsyncSessionMiddleware, key=_DEFAULT_SESSION_KEY
+    )

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -52,8 +52,7 @@ def test_setup_multiple_engines(db_url):
 
     assert app.add_middleware.call_count == 2
     assert all(
-        call.args[0] == sqla.SessionMiddleware
-        for call in app.middleware.call_args_list
+        call.args[0] == sqla.SessionMiddleware for call in app.middleware.call_args_list
     )
 
     assert any(
@@ -130,10 +129,7 @@ def test_setup_with_async_default_sqlalchemy_url(async_sqlalchemy_url):
     }
 
     app.add_middleware.assert_called_once()
-    assert (
-        app.add_middleware.call_args.args[0]
-        == async_sqla.AsyncSessionMiddleware
-    )
+    assert app.add_middleware.call_args.args[0] == async_sqla.AsyncSessionMiddleware
     assert app.add_middleware.call_args.kwargs["key"] == _DEFAULT_SESSION_KEY
 
 

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -55,18 +55,8 @@ def test_setup_multiple_engines(db_url):
         call.args[0] == sqla.SessionMiddleware for call in app.middleware.call_args_list
     )
 
-    assert any(
-        call
-        for call in app.add_middleware.call_args_list
-        if call.args[0] == sqla.SessionMiddleware
-        and call.kwargs["key"] == _DEFAULT_SESSION_KEY
-    )
-    assert any(
-        call
-        for call in app.add_middleware.call_args_list
-        if call.args[0] == sqla.SessionMiddleware
-        and call.kwargs["key"] == read_only_key
-    )
+    app.add_middleware.assert_any_call(sqla.SessionMiddleware, key=_DEFAULT_SESSION_KEY)
+    app.add_middleware.assert_any_call(sqla.SessionMiddleware, key=read_only_key)
 
 
 @mark.sqlalchemy("1.4")
@@ -95,17 +85,9 @@ def test_setup_with_sync_and_async_sqlalchemy_url(async_session_key):
     )
 
     assert app.add_middleware.call_count == 2
-    assert any(
-        call
-        for call in app.add_middleware.call_args_list
-        if call.args[0] == sqla.SessionMiddleware
-        and call.kwargs["key"] == _DEFAULT_SESSION_KEY
-    )
-    assert any(
-        call
-        for call in app.add_middleware.call_args_list
-        if call.args[0] == async_sqla.AsyncSessionMiddleware
-        and call.kwargs["key"] == async_session_key
+    app.add_middleware.assert_any_call(sqla.SessionMiddleware, key=_DEFAULT_SESSION_KEY)
+    app.add_middleware.assert_any_call(
+        async_sqla.AsyncSessionMiddleware, key=async_session_key
     )
 
 
@@ -128,9 +110,9 @@ def test_setup_with_async_default_sqlalchemy_url(async_sqlalchemy_url):
         "key": _DEFAULT_SESSION_KEY
     }
 
-    app.add_middleware.assert_called_once()
-    assert app.add_middleware.call_args.args[0] == async_sqla.AsyncSessionMiddleware
-    assert app.add_middleware.call_args.kwargs["key"] == _DEFAULT_SESSION_KEY
+    app.add_middleware.assert_called_once_with(
+        async_sqla.AsyncSessionMiddleware, key=_DEFAULT_SESSION_KEY
+    )
 
 
 @mark.parametrize(


### PR DESCRIPTION
## Problem

When using multiple sessions, we've seen sporadic issues coming from the injected middlewares where the response body is missing, causing errors due to a mismatch with the promised `Content-Length`. We've also observed a significant increase in endpoint latency.

Besides, the middleware class we're using, [`BaseHTTPMiddleware`](https://www.starlette.io/middleware/#basehttpmiddleware), is no longer the recommended way of writing middlewares for Starlette. It's known to have functional issues and does not scale well (see [discussion on this FastAPI issue](https://github.com/tiangolo/fastapi/discussions/6985#discussioncomment-8989601), [discussion on this Starlette issue](https://github.com/encode/starlette/issues/1634#issuecomment-1124806406), and [this performance benchmark](https://kisspeter.github.io/fastapi-performance-optimization/middleware.html)).

## Solution

Refactor the middleware used to inject sessions into the request, to be [pure ASGI middleware](https://www.starlette.io/middleware/#pure-asgi-middleware).

## Related

* [DIA-70887]
* https://github.com/dialoguemd/coredata/pull/1856

## Validation

✅  Tests are passing
✅  ER smoke tests with 2 sessions - calls are successful, both middlewares are present and executed ([sample request - only the default session is used](https://app.datadoghq.com/logs?query=%40request_headers.x-datadog-trace-id%3A16365759639994361819&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=desc&view=spans&viz=stream&from_ts=1718998428120&to_ts=1718998434278&live=false), [sample request - both sessions are used](https://app.datadoghq.com/logs?query=%40request_headers.x-datadog-trace-id%3A16918563406151202983&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=desc&view=spans&viz=stream&from_ts=1718998620000&to_ts=1718998800000&live=false))

[DIA-61986]: https://dialoguemd.atlassian.net/browse/DIA-61986?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[DIA-70887]: https://dialoguemd.atlassian.net/browse/DIA-70887?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ