### PR TITLE
fix(deps): use inequality for all dependencies

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2043,4 +2043,4 @@ sqlmodel = ["sqlmodel"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<3.13"
-content-hash = "1a0e8a059c2f93524064bfa323efb7a8dbeaa72892c6e15245b6ecb47f170659"
+content-hash = "b2aa2caa3ed1c791abe02d693594d0cc67bb5552873645c006ca754251efb750"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,13 +43,13 @@ fastapi = ">=0.95.1,<0.112"
 pydantic = ">=1,<3"
 sqlalchemy = ">=1.3,<3"
 structlog = ">=20,<25"
-deprecated = "^1.2"
+deprecated = ">=1.2,<2"
 
-alembic = { version = "^1.4.3", optional = true }
-asyncpg = { version = "^0.28.0 || ^0.29.0", optional = true }
-boto3 = { version = "^1.24.74", optional = true }
-psycopg2 = { version = "^2.8.6", optional = true }
-sqlmodel = { version = "^0.0.14 || ^0.0.19", optional = true }
+alembic = { version = ">=1.4.3,<2", optional = true }
+asyncpg = { version = ">=0.28.0,<0.30.0", optional = true }
+boto3 = { version = ">=1.24.74,<2", optional = true }
+psycopg2 = { version = ">=2.8.6,<3", optional = true }
+sqlmodel = { version = ">=0.0.14,<0.0.20", optional = true }
 
 [tool.poetry.group.dev.dependencies]
 alembic = "1.13.2"


### PR DESCRIPTION
## Problem

With the `widen` strategy from Renovate, dependencies are bumped from e.g. `^0.14.0` to `^0.14.0 || ^0.19.0` when a new version is available. That's not what we want, and this is also rejected by PyPI ([example](https://app.circleci.com/pipelines/github/dialoguemd/fastapi-sqla/1086/workflows/aaf2551e-d461-4eaa-9bdd-0f88d54a35b6/jobs/36952?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-checks-link&utm_content=summary)) which prevents the library from being published.

## Solution

Use ranges for all dependencies, as [that seems to work](https://github.com/dialoguemd/guestlist/pull/302).

## Related

* [DIA-70894]

## Validation

Can only be validated after merging & running Renovate

[DIA-70894]: https://dialoguemd.atlassian.net/browse/DIA-70894?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ