### PR TITLE
feat(pytest): support startup in tests

### DIFF
--- a/fastapi_sqla/_pytest_plugin.py
+++ b/fastapi_sqla/_pytest_plugin.py
@@ -124,18 +124,18 @@ def patch_new_engine(request: FixtureRequest, sqla_connection: Connection):
 @fixture
 def session_factory(
     sqla_connection: Connection, sqla_reflection, patch_new_engine
-) -> sessionmaker[Session]:
+) -> sessionmaker:
     return sessionmaker(bind=sqla_connection)
 
 
 @fixture
-def session(session_factory: sessionmaker[Session]) -> Generator[Session]:
+def session(session_factory: sessionmaker) -> Generator[Session]:
     """Sqla session to use when creating db fixtures.
 
     While it does not write any record in DB, the application will still be able to
     access any record committed with that session.
     """
-    session = session_factory()
+    session: Session = session_factory()
     yield session
     session.close()
 
@@ -197,14 +197,14 @@ if asyncio_support:
         async_sqla_connection: AsyncConnection,
         async_sqla_reflection,
         patch_new_async_engine,
-    ) -> sessionmaker[AsyncSession]:  # type: ignore
+    ) -> sessionmaker:
         # TODO: Use async_sessionmaker once only supporting 2.x+
         return sessionmaker(bind=async_sqla_connection, class_=AsyncSession)  # type: ignore
 
     @fixture
     async def async_session(
-        async_session_factory: sessionmaker[AsyncSession],  # type: ignore
+        async_session_factory: sessionmaker,
     ) -> AsyncGenerator[AsyncSession]:
-        session = async_session_factory()
+        session: AsyncSession = async_session_factory()
         yield session
         await session.close()

--- a/fastapi_sqla/_pytest_plugin.py
+++ b/fastapi_sqla/_pytest_plugin.py
@@ -104,7 +104,7 @@ def sqla_modules():
 def sqla_reflection(sqla_modules, sqla_connection: Connection):
     import fastapi_sqla
 
-    fastapi_sqla.Base.metadata.bind = sqla_connection
+    fastapi_sqla.Base.metadata.bind = sqla_connection  # type: ignore
     fastapi_sqla.Base.prepare(sqla_connection.engine)
 
 
@@ -197,12 +197,13 @@ if asyncio_support:
         async_sqla_connection: AsyncConnection,
         async_sqla_reflection,
         patch_new_async_engine,
-    ) -> sessionmaker[AsyncSession]:
-        return sessionmaker(bind=async_sqla_connection, class_=AsyncSession)
+    ) -> sessionmaker[AsyncSession]:  # type: ignore
+        # TODO: Use async_sessionmaker once only supporting 2.x+
+        return sessionmaker(bind=async_sqla_connection, class_=AsyncSession)  # type: ignore
 
     @fixture
     async def async_session(
-        async_session_factory: sessionmaker[AsyncSession],
+        async_session_factory: sessionmaker[AsyncSession],  # type: ignore
     ) -> AsyncGenerator[AsyncSession]:
         session = async_session_factory()
         yield session

--- a/fastapi_sqla/_pytest_plugin.py
+++ b/fastapi_sqla/_pytest_plugin.py
@@ -199,7 +199,9 @@ if asyncio_support:
         patch_new_async_engine,
     ) -> sessionmaker:
         # TODO: Use async_sessionmaker once only supporting 2.x+
-        return sessionmaker(bind=async_sqla_connection, class_=AsyncSession)  # type: ignore
+        return sessionmaker(
+            bind=async_sqla_connection, expire_on_commit=False, class_=AsyncSession
+        )  # type: ignore
 
     @fixture
     async def async_session(

--- a/fastapi_sqla/base.py
+++ b/fastapi_sqla/base.py
@@ -1,10 +1,11 @@
 import functools
 import os
 import re
+from typing import Union
 
 from deprecated import deprecated
 from fastapi import FastAPI
-from sqlalchemy.engine import Engine
+from sqlalchemy.engine import Connection, Engine
 
 from fastapi_sqla import sqla
 
@@ -72,5 +73,5 @@ def _get_engine_keys() -> set[str]:
     return keys
 
 
-def _is_async_dialect(engine: Engine):
+def _is_async_dialect(engine: Union[Engine, Connection]):
     return engine.dialect.is_async if hasattr(engine.dialect, "is_async") else False

--- a/fastapi_sqla/sqla.py
+++ b/fastapi_sqla/sqla.py
@@ -58,17 +58,18 @@ def startup(key: str = _DEFAULT_SESSION_KEY):
     aws_aurora_support.setup(engine.engine)
 
     # Fail early
-    try:
-        with engine.connect() as connection:
-            connection.execute(text("select 'OK'"))
-    except Exception:
-        logger.critical(
-            f"Failed querying db for key '{key}': "
-            "are the the environment variables correctly configured for this key?"
-        )
-        raise
+    if not bool(os.getenv("FASTAPI_SQLA_TEST_MODE")):
+        try:
+            with engine.connect() as connection:
+                connection.execute(text("select 'OK'"))
+        except Exception:
+            logger.critical(
+                f"Failed querying db for key '{key}': "
+                "are the the environment variables correctly configured for this key?"
+            )
+            raise
 
-    Base.prepare(engine)
+        Base.prepare(engine)
 
     _session_factories[key] = sessionmaker(bind=engine, class_=SqlaSession)
 

--- a/fastapi_sqla/sqla.py
+++ b/fastapi_sqla/sqla.py
@@ -42,11 +42,16 @@ class Base(DeclarativeBase, DeferredReflection):
     __abstract__ = True
 
 
-def new_engine(key: str = _DEFAULT_SESSION_KEY) -> Union[Engine, Connection]:
+def get_envvar_prefix(key: str) -> str:
     envvar_prefix = "sqlalchemy_"
     if key != _DEFAULT_SESSION_KEY:
         envvar_prefix = f"fastapi_sqla__{key}__{envvar_prefix}"
 
+    return envvar_prefix
+
+
+def new_engine(key: str = _DEFAULT_SESSION_KEY) -> Union[Engine, Connection]:
+    envvar_prefix = get_envvar_prefix(key)
     lowercase_environ = {k.lower(): v for k, v in os.environ.items()}
     lowercase_environ.pop(f"{envvar_prefix}warn_20", None)
     return engine_from_config(lowercase_environ, prefix=envvar_prefix)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,8 +73,8 @@ psycopg2 = ["psycopg2"]
 sqlmodel = ["sqlmodel"]
 
 [build-system]
-requires = ["poetry>=1.3.0"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
 
 [tool.semantic_release]
 version_toml = ["pyproject.toml:tool.poetry.version"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,8 +73,8 @@ psycopg2 = ["psycopg2"]
 sqlmodel = ["sqlmodel"]
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
-build-backend = "poetry.core.masonry.api"
+requires = ["poetry>=1.3.0"]
+build-backend = "poetry.masonry.api"
 
 [tool.semantic_release]
 version_toml = ["pyproject.toml:tool.poetry.version"]

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -206,3 +206,13 @@ async def test_async_session_fixture_patch_startup(async_session, singer_cls):
         new_session.add(singer_cls(id=1, name="Bob Marley", country="Jamaica"))
 
     assert await async_session.get(singer_cls, 1)
+
+
+@mark.require_asyncpg
+@mark.sqlalchemy("1.4")
+async def test_async_session_fixture_doesnt_expire_on_commit(async_session, singer_cls):
+    singer = singer_cls(id=1, name="Bob Marley", country="Jamaica")
+    async_session.add(singer)
+    await async_session.commit()
+
+    assert singer.name == "Bob Marley"

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -89,23 +89,23 @@ async def test_async_session_fixture_dont_patch_engine_writes_in_db(
 
 @mark.sqlalchemy("1.4")
 def test_all_opened_sessions_are_within_the_same_transaction(
-    sqla_connection, session, session_factory, singer_cls
+    session, session_factory, singer_cls
 ):
     session.add(singer_cls(id=1, name="Bob Marley", country="Jamaica"))
     session.commit()
 
-    other_session = session_factory(bind=sqla_connection)
+    other_session = session_factory()
 
     assert other_session.get(singer_cls, 1)
 
 
 def test_sqla_13_all_opened_sessions_are_within_the_same_transaction(
-    sqla_connection, session, session_factory, singer_cls
+    session, session_factory, singer_cls
 ):
     session.add(singer_cls(id=1, name="Bob Marley", country="Jamaica"))
     session.commit()
 
-    other_session = session_factory(bind=sqla_connection)
+    other_session = session_factory()
 
     assert other_session.query(singer_cls).get(1)
 
@@ -113,12 +113,12 @@ def test_sqla_13_all_opened_sessions_are_within_the_same_transaction(
 @mark.require_asyncpg
 @mark.sqlalchemy("1.4")
 async def test_all_opened_async_sessions_are_within_the_same_transaction(
-    async_sqla_connection, async_session, async_session_factory, singer_cls
+    async_session, async_session_factory, singer_cls
 ):
     async_session.add(singer_cls(id=1, name="Bob Marley", country="Jamaica"))
     await async_session.commit()
 
-    other_session = async_session_factory(bind=async_sqla_connection)
+    other_session = async_session_factory()
     assert await other_session.get(singer_cls, 1)
 
 

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -192,3 +192,17 @@ async def test_session_fixture_patch_startup(session, singer_cls):
         new_session.add(singer_cls(id=1, name="Bob Marley", country="Jamaica"))
 
     assert session.query(singer_cls).get(1)
+
+
+@mark.require_asyncpg
+@mark.sqlalchemy("1.4")
+async def test_async_session_fixture_patch_startup(async_session, singer_cls):
+    from fastapi_sqla import open_async_session
+    from fastapi_sqla.async_sqla import startup
+
+    await startup()
+
+    async with open_async_session() as new_session:
+        new_session.add(singer_cls(id=1, name="Bob Marley", country="Jamaica"))
+
+    assert await async_session.get(singer_cls, 1)

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -181,3 +181,14 @@ def test_format_async_sqlalchemy_url(monkeypatch, conftest, testdir, url, expect
     from fastapi_sqla._pytest_plugin import format_async_async_sqlalchemy_url
 
     assert format_async_async_sqlalchemy_url(url) == expected
+
+
+async def test_session_fixture_patch_startup(session, singer_cls):
+    from fastapi_sqla import open_session, startup
+
+    await startup()
+
+    with open_session() as new_session:
+        new_session.add(singer_cls(id=1, name="Bob Marley", country="Jamaica"))
+
+    assert session.query(singer_cls).get(1)


### PR DESCRIPTION
## Problem

In the pytest plugin, we patch the `sqla.new_engine` function (and its async equivalent) to return a `Connection` object. This causes issue when running the `startup` function to initialize the session factories, since it expects an engine and uses it to validate that it can connect to the database.

## Solution

Update the `sqla` and `asyncsqla` module to properly represent that `new_engine` can return either an Engine or a Connection. Update their `startup` function to properly handle both classes.

### Additional changes
- Properly type the pytest plugin to ease working on it
- Align `patch_new_engine` and `patch_new_async_engine` fixture implementation to close the transaction on tear down.
- Patch the `new_engine` and `new_async_engine` methods directly in the pytest plugin instead of patching the sqlalchemy function, so it's easier to reason about.
- Update the fixture request tree so that the `session_factory` fixture always returns session bound to the main test connection.
- Update the `async_session_factory` fixture to set `expire_on_commit=False` in order to allow accessing attributes after a commit.

## Validation

Tests are added to confirm that the startup function can safely be called and that it works with `open_session`. ✅ 

Tested with [document-center](https://github.com/dialoguemd/document-center/pull/904) to unblock the upgrade to 3.x ✅ 

<!-- 📋 Checklist:
1. Title follows [Commit Convention] and [Code Review guidelines]
   - example: feat(lang): add German language - DIA-12345
2. Relevant labels set
3. Draft PR for WIP
4. Validation notes added
5. Requested from and notified to a team

[Commit Convention]: https://www.notion.so/godialogue/Commit-Convention-84fd9a4c149e48c998d760f1c9176df0
[Code Review guidelines]: https://www.notion.so/godialogue/Code-Review-c5f3fcd185ca49aca73ade497c398fe9  -->
