### PR TITLE
chore(orbs) decommission slack (PLAT-98)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,9 @@
 version: 2.1
 
 orbs:
-  base: dialogue/base@1.23.7
-  release: dialogue/release@2.19.7
-  python: dialogue/python@3.25.2
+  base: dialogue/base@dev:1f890ed
+  release: dialogue/release@dev:1f890ed
+  python: dialogue/python@dev:1f890ed
   utils: dialogue/utils@3.19.7
   codecov: codecov/codecov@4.1.0
 
@@ -58,7 +58,6 @@ workflows:
             - 👮 lint
             - 👮 mypy
           context:
-            - slack-release
             - base-github-ci
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,10 +1,10 @@
 version: 2.1
 
 orbs:
-  base: dialogue/base@dev:1f890ed
-  release: dialogue/release@dev:1f890ed
-  python: dialogue/python@dev:1f890ed
-  utils: dialogue/utils@3.19.7
+  base: dialogue/base@1.26.2
+  release: dialogue/release@2.23.0
+  python: dialogue/python@3.30.0
+  utils: dialogue/utils@3.22.2
   codecov: codecov/codecov@4.1.0
 
 aliases:


### PR DESCRIPTION
## Problem

Slack notifications not relevant anymore

## Solution

Upgrade to latest orbs and remove references to slack one

## Related

* [PLAT-98]

## Validation



[PLAT-98]: https://dialoguemd.atlassian.net/browse/PLAT-98?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ