### PR TITLE
feat: improve performance of default pagination count queries

### DIFF
--- a/fastapi_sqla/async_pagination.py
+++ b/fastapi_sqla/async_pagination.py
@@ -19,6 +19,15 @@ PaginateDependency = Union[DefaultDependency, WithQueryCountDependency]
 
 
 async def default_query_count(session: SqlaAsyncSession, query: Select) -> int:
+    """Default function used to count items returned by a query.
+
+    It includes some performance optimizations (selecting no columns, removing sorting).
+
+    See:
+    - https://gist.github.com/hest/8798884
+    - https://datawookie.dev/blog/2021/01/sqlalchemy-efficient-counting/
+    """
+    query = query.with_only_columns(1).order_by(None)
     result = await session.execute(select(func.count()).select_from(query.subquery()))
     return cast(int, result.scalar())
 

--- a/fastapi_sqla/async_pagination.py
+++ b/fastapi_sqla/async_pagination.py
@@ -3,7 +3,7 @@ from collections.abc import Awaitable, Callable, Iterator
 from typing import Annotated, Optional, Union, cast
 
 from fastapi import Depends, Query
-from sqlalchemy.sql import Select, func, select
+from sqlalchemy.sql import Select, func, literal_column
 
 from fastapi_sqla.async_sqla import AsyncSessionDependency, SqlaAsyncSession
 from fastapi_sqla.models import Meta, Page
@@ -27,9 +27,10 @@ async def default_query_count(session: SqlaAsyncSession, query: Select) -> int:
     - https://gist.github.com/hest/8798884
     - https://datawookie.dev/blog/2021/01/sqlalchemy-efficient-counting/
     """
-    query = query.with_only_columns(1).order_by(None)
-    result = await session.execute(select(func.count()).select_from(query.subquery()))
-    return cast(int, result.scalar())
+    result = await session.exec(
+        query.with_only_columns(func.count(literal_column("1"))).order_by(None)
+    )
+    return cast(int, result)
 
 
 async def paginate_query(

--- a/fastapi_sqla/async_pagination.py
+++ b/fastapi_sqla/async_pagination.py
@@ -27,10 +27,10 @@ async def default_query_count(session: SqlaAsyncSession, query: Select) -> int:
     - https://gist.github.com/hest/8798884
     - https://datawookie.dev/blog/2021/01/sqlalchemy-efficient-counting/
     """
-    result = await session.exec(
+    result = await session.execute(
         query.with_only_columns(func.count(literal_column("1"))).order_by(None)
     )
-    return cast(int, result)
+    return cast(int, result.scalar())
 
 
 async def paginate_query(

--- a/fastapi_sqla/pagination.py
+++ b/fastapi_sqla/pagination.py
@@ -33,9 +33,9 @@ def default_query_count(session: SqlaSession, query: DbQuery) -> int:
     elif isinstance(query, Select):
         result = cast(
             int,
-            session.exec(
+            session.execute(
                 query.with_only_columns(func.count(literal_column("1"))).order_by(None)
-            ),
+            ).scalar(),
         )
 
     else:  # pragma: no cover

--- a/fastapi_sqla/pagination.py
+++ b/fastapi_sqla/pagination.py
@@ -21,15 +21,17 @@ PaginateDependency = Union[DefaultDependency, WithQueryCountDependency]
 def default_query_count(session: SqlaSession, query: DbQuery) -> int:
     """Default function used to count items returned by a query.
 
-    It is slower than a manually written query could be: It runs the query in a
-    subquery, and count the number of elements returned.
+    It includes some performance optimizations (selecting no columns, removing sorting).
 
-    See https://gist.github.com/hest/8798884
+    See:
+    - https://gist.github.com/hest/8798884
+    - https://datawookie.dev/blog/2021/01/sqlalchemy-efficient-counting/
     """
     if isinstance(query, LegacyQuery):
         result = query.count()
 
     elif isinstance(query, Select):
+        query = query.with_only_columns(1).order_by(None)
         result = cast(
             int,
             session.execute(

--- a/fastapi_sqla/pagination.py
+++ b/fastapi_sqla/pagination.py
@@ -5,7 +5,7 @@ from typing import Annotated, Optional, Union, cast
 
 from fastapi import Depends, Query
 from sqlalchemy.orm import Query as LegacyQuery
-from sqlalchemy.sql import Select, func, select
+from sqlalchemy.sql import Select, func, literal_column
 
 from fastapi_sqla.models import Meta, Page
 from fastapi_sqla.sqla import _DEFAULT_SESSION_KEY, SessionDependency, SqlaSession
@@ -31,12 +31,11 @@ def default_query_count(session: SqlaSession, query: DbQuery) -> int:
         result = query.count()
 
     elif isinstance(query, Select):
-        query = query.with_only_columns(1).order_by(None)
         result = cast(
             int,
-            session.execute(
-                select(func.count()).select_from(query.subquery())
-            ).scalar(),
+            session.exec(
+                query.with_only_columns(func.count(literal_column("1"))).order_by(None)
+            ),
         )
 
     else:  # pragma: no cover


### PR DESCRIPTION
## Problem

The default queries used to count total items in the pagination modules are not very efficient, especially for more complex queries.

## Solution

Improve the performance of the default queries by stripping column selection and removing any sorting of results, since we only care about the total count of items.

## Related

* [DIA-XXXXX]

## Validation

🚧  In progress