### PR TITLE
feat: set hide params to true postgres engine [DIA-86641]

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,24 @@ And define the environment variable `sqlalchemy_url` with `postgres+asyncpg` sch
 export sqlalchemy_url=postgresql+asyncpg://postgres@localhost
 ```
 
+### Hiding SQL parameters
+
+By default, `hide_parameters` is set to `True` on all engines to prevent SQL query
+parameters from appearing in error messages and logs. This helps protect sensitive data
+such as PII/PHI.
+
+To disable this (e.g. for local debugging or dev):
+
+```bash
+export sqlalchemy_hide_parameters=false
+```
+
+For named sessions:
+
+```bash
+export fastapi_sqla__read_only__sqlalchemy_hide_parameters=false
+```
+
 ## Setup the app AsyncContextManager (recommended):
 
 ```python

--- a/fastapi_sqla/_pytest_plugin.py
+++ b/fastapi_sqla/_pytest_plugin.py
@@ -58,7 +58,7 @@ def db_url(db_host: str, db_user: str) -> str:
 
 @fixture(scope="session")
 def engine(db_url: str) -> Engine:
-    return create_engine(db_url, hide_parameters=True)
+    return create_engine(db_url)
 
 
 @fixture(scope="session")
@@ -159,7 +159,7 @@ if asyncio_support:
 
     @fixture
     def async_engine(async_sqlalchemy_url: str) -> AsyncEngine:
-        return create_async_engine(async_sqlalchemy_url, hide_parameters=True)
+        return create_async_engine(async_sqlalchemy_url)
 
     @fixture
     async def async_sqla_connection(

--- a/fastapi_sqla/_pytest_plugin.py
+++ b/fastapi_sqla/_pytest_plugin.py
@@ -58,7 +58,7 @@ def db_url(db_host: str, db_user: str) -> str:
 
 @fixture(scope="session")
 def engine(db_url: str) -> Engine:
-    return create_engine(db_url)
+    return create_engine(db_url, hide_parameters=True)
 
 
 @fixture(scope="session")
@@ -159,7 +159,7 @@ if asyncio_support:
 
     @fixture
     def async_engine(async_sqlalchemy_url: str) -> AsyncEngine:
-        return create_async_engine(async_sqlalchemy_url)
+        return create_async_engine(async_sqlalchemy_url, hide_parameters=True)
 
     @fixture
     async def async_sqla_connection(

--- a/fastapi_sqla/async_sqla.py
+++ b/fastapi_sqla/async_sqla.py
@@ -1,4 +1,3 @@
-import os
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from typing import Annotated, Union

--- a/fastapi_sqla/async_sqla.py
+++ b/fastapi_sqla/async_sqla.py
@@ -20,7 +20,7 @@ from fastapi_sqla import aws_aurora_support, aws_rds_iam_support
 from fastapi_sqla.sqla import (
     _DEFAULT_SESSION_KEY,
     Base,
-    _resolve_hide_parameters,
+    _apply_engine_defaults,
     get_envvar_prefix,
 )
 
@@ -36,9 +36,9 @@ def new_async_engine(
     envvar_prefix = get_envvar_prefix(key)
     lowercase_environ = {k.lower(): v for k, v in os.environ.items()}
     lowercase_environ.pop(f"{envvar_prefix}warn_20", None)
-    hide_parameters = _resolve_hide_parameters(lowercase_environ, envvar_prefix)
+    engine_defaults = _apply_engine_defaults(lowercase_environ, envvar_prefix)
     return async_engine_from_config(
-        lowercase_environ, prefix=envvar_prefix, hide_parameters=hide_parameters
+        lowercase_environ, prefix=envvar_prefix, **engine_defaults
     )
 
 

--- a/fastapi_sqla/async_sqla.py
+++ b/fastapi_sqla/async_sqla.py
@@ -20,7 +20,7 @@ from fastapi_sqla import aws_aurora_support, aws_rds_iam_support
 from fastapi_sqla.sqla import (
     _DEFAULT_SESSION_KEY,
     Base,
-    _apply_engine_defaults,
+    _get_engine_config,
     get_envvar_prefix,
 )
 
@@ -34,12 +34,8 @@ def new_async_engine(
     key: str = _DEFAULT_SESSION_KEY,
 ) -> Union[AsyncEngine, AsyncConnection]:
     envvar_prefix = get_envvar_prefix(key)
-    lowercase_environ = {k.lower(): v for k, v in os.environ.items()}
-    lowercase_environ.pop(f"{envvar_prefix}warn_20", None)
-    engine_defaults = _apply_engine_defaults(lowercase_environ, envvar_prefix)
-    return async_engine_from_config(
-        lowercase_environ, prefix=envvar_prefix, **engine_defaults
-    )
+    config = _get_engine_config(envvar_prefix)
+    return async_engine_from_config(config, prefix=envvar_prefix)
 
 
 async def startup(key: str = _DEFAULT_SESSION_KEY):

--- a/fastapi_sqla/async_sqla.py
+++ b/fastapi_sqla/async_sqla.py
@@ -31,7 +31,9 @@ def new_async_engine(
     envvar_prefix = get_envvar_prefix(key)
     lowercase_environ = {k.lower(): v for k, v in os.environ.items()}
     lowercase_environ.pop(f"{envvar_prefix}warn_20", None)
-    return async_engine_from_config(lowercase_environ, prefix=envvar_prefix, hide_parameters=True)
+    return async_engine_from_config(
+        lowercase_environ, prefix=envvar_prefix, hide_parameters=True
+    )
 
 
 async def startup(key: str = _DEFAULT_SESSION_KEY):

--- a/fastapi_sqla/async_sqla.py
+++ b/fastapi_sqla/async_sqla.py
@@ -31,7 +31,7 @@ def new_async_engine(
     envvar_prefix = get_envvar_prefix(key)
     lowercase_environ = {k.lower(): v for k, v in os.environ.items()}
     lowercase_environ.pop(f"{envvar_prefix}warn_20", None)
-    return async_engine_from_config(lowercase_environ, prefix=envvar_prefix)
+    return async_engine_from_config(lowercase_environ, prefix=envvar_prefix, hide_parameters=True)
 
 
 async def startup(key: str = _DEFAULT_SESSION_KEY):

--- a/fastapi_sqla/async_sqla.py
+++ b/fastapi_sqla/async_sqla.py
@@ -17,7 +17,12 @@ from sqlalchemy.orm.session import sessionmaker
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 from fastapi_sqla import aws_aurora_support, aws_rds_iam_support
-from fastapi_sqla.sqla import _DEFAULT_SESSION_KEY, Base, get_envvar_prefix
+from fastapi_sqla.sqla import (
+    _DEFAULT_SESSION_KEY,
+    Base,
+    _resolve_hide_parameters,
+    get_envvar_prefix,
+)
 
 logger = structlog.get_logger(__name__)
 
@@ -31,8 +36,9 @@ def new_async_engine(
     envvar_prefix = get_envvar_prefix(key)
     lowercase_environ = {k.lower(): v for k, v in os.environ.items()}
     lowercase_environ.pop(f"{envvar_prefix}warn_20", None)
+    hide_parameters = _resolve_hide_parameters(lowercase_environ, envvar_prefix)
     return async_engine_from_config(
-        lowercase_environ, prefix=envvar_prefix, hide_parameters=True
+        lowercase_environ, prefix=envvar_prefix, hide_parameters=hide_parameters
     )
 
 

--- a/fastapi_sqla/sqla.py
+++ b/fastapi_sqla/sqla.py
@@ -75,8 +75,7 @@ def _get_engine_config(
         if k.startswith(envvar_prefix)
     }
     config = _EngineConfig(**overrides)  # type: ignore[arg-type]
-    coerced = config.dict()
-    for param, value in coerced.items():
+    for param, value in config.dict().items():
         lowercase_env[f"{envvar_prefix}{param}"] = value
 
     return lowercase_env

--- a/fastapi_sqla/sqla.py
+++ b/fastapi_sqla/sqla.py
@@ -9,7 +9,6 @@ from fastapi import Depends, Request, Response
 from fastapi.concurrency import contextmanager_in_threadpool
 from fastapi.responses import PlainTextResponse
 from pydantic import BaseModel
-from pydantic import __version__ as pydantic_version
 from sqlalchemy import engine_from_config, text
 from sqlalchemy.engine import Connection, Engine
 from sqlalchemy.ext.declarative import DeferredReflection
@@ -40,26 +39,13 @@ _REQUEST_SESSION_KEY = "fastapi_sqla_session"
 _session_factories: dict[str, sessionmaker] = {}
 
 
-_pydantic_major = int(pydantic_version.split(".")[0])
+class _EngineConfig(BaseModel):
+    """Engine configuration with typed defaults and bool coercion."""
 
-if _pydantic_major == 2:
-    from pydantic import ConfigDict
+    hide_parameters: bool = True
 
-    class _EngineConfig(BaseModel):
-        """Engine configuration with typed defaults and bool coercion."""
-
-        model_config = ConfigDict(extra="allow")
-        hide_parameters: bool = True
-
-else:
-
-    class _EngineConfig(BaseModel):  # type: ignore[no-redef]
-        """Engine configuration with typed defaults and bool coercion."""
-
-        hide_parameters: bool = True
-
-        class Config:
-            extra = "allow"
+    class Config:
+        extra = "allow"
 
 
 class Base(DeclarativeBase, DeferredReflection):
@@ -89,7 +75,7 @@ def _get_engine_config(
         if k.startswith(envvar_prefix)
     }
     config = _EngineConfig(**overrides)  # type: ignore[arg-type]
-    coerced = config.model_dump() if _pydantic_major == 2 else config.dict()
+    coerced = config.dict()
     for param, value in coerced.items():
         lowercase_env[f"{envvar_prefix}{param}"] = value
 

--- a/fastapi_sqla/sqla.py
+++ b/fastapi_sqla/sqla.py
@@ -104,7 +104,7 @@ def _get_engine_config(
     lowercase_env.pop(f"{envvar_prefix}warn_20", None)
 
     overrides = {
-        k[len(envvar_prefix):]: v
+        k[len(envvar_prefix) :]: v
         for k, v in lowercase_env.items()
         if k.startswith(envvar_prefix)
     }

--- a/fastapi_sqla/sqla.py
+++ b/fastapi_sqla/sqla.py
@@ -9,7 +9,6 @@ from fastapi import Depends, Request, Response
 from fastapi.concurrency import contextmanager_in_threadpool
 from fastapi.responses import PlainTextResponse
 from pydantic import BaseModel
-from pydantic import __version__ as pydantic_version
 from sqlalchemy import engine_from_config, text
 from sqlalchemy.engine import Connection, Engine
 from sqlalchemy.ext.declarative import DeferredReflection
@@ -19,14 +18,17 @@ from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 from fastapi_sqla import aws_aurora_support, aws_rds_iam_support
 
-_pydantic_major = int(pydantic_version.split(".")[0])
-
 try:
     from sqlalchemy.orm import DeclarativeBase
 except ImportError:
     from sqlalchemy.ext.declarative import declarative_base
 
     DeclarativeBase = declarative_base()  # type: ignore
+
+try:
+    from pydantic import ConfigDict as _ConfigDict
+except ImportError:
+    _ConfigDict = None  # type: ignore[assignment,misc]
 
 try:
     from sqlmodel import Session as SqlaSession  # type: ignore
@@ -42,33 +44,15 @@ _REQUEST_SESSION_KEY = "fastapi_sqla_session"
 _session_factories: dict[str, sessionmaker] = {}
 
 
-def _coerce_bool_strings(data: dict) -> dict:
-    """Coerce 'true'/'false' strings to bool in a dict."""
-    coerced = {}
-    for k, v in data.items():
-        if isinstance(v, str) and v.lower() in ("true", "false"):
-            coerced[k] = v.lower() == "true"
-        else:
-            coerced[k] = v
-    return coerced
-
-
-if _pydantic_major == 2:
-    from pydantic import model_validator
+if _ConfigDict is not None:
 
     class _EngineConfig(BaseModel):
         """Engine configuration with typed defaults and bool coercion."""
 
-        model_config = {"extra": "allow"}
+        model_config = _ConfigDict(extra="allow")
         hide_parameters: bool = True
 
-        @model_validator(mode="before")
-        @classmethod
-        def coerce_booleans(cls, data):
-            return _coerce_bool_strings(data)
-
 else:
-    from pydantic import root_validator
 
     class _EngineConfig(BaseModel):  # type: ignore[no-redef]
         """Engine configuration with typed defaults and bool coercion."""
@@ -77,10 +61,6 @@ else:
 
         class Config:
             extra = "allow"
-
-        @root_validator(pre=True, allow_reuse=True)
-        def coerce_booleans(cls, values):  # noqa: N805
-            return _coerce_bool_strings(values)
 
 
 class Base(DeclarativeBase, DeferredReflection):
@@ -110,7 +90,7 @@ def _get_engine_config(
         if k.startswith(envvar_prefix)
     }
     config = _EngineConfig(**overrides)  # type: ignore[arg-type]
-    coerced = config.model_dump() if _pydantic_major == 2 else config.dict()
+    coerced = config.model_dump() if hasattr(config, "model_dump") else config.dict()
     for param, value in coerced.items():
         lowercase_env[f"{envvar_prefix}{param}"] = value
 

--- a/fastapi_sqla/sqla.py
+++ b/fastapi_sqla/sqla.py
@@ -42,24 +42,23 @@ _REQUEST_SESSION_KEY = "fastapi_sqla_session"
 _session_factories: dict[str, sessionmaker] = {}
 
 
-def _coerce_bool_string(value):
-    if isinstance(value, str):
-        lowered = value.lower()
-        if lowered == "true":
-            return True
-        if lowered == "false":
-            return False
-    return value
-
-
-def _coerce_bool_strings(data):
-    return {k: _coerce_bool_string(v) for k, v in data.items()}
+def _coerce_bool_strings(data: dict) -> dict:
+    """Coerce 'true'/'false' strings to bool in a dict."""
+    coerced = {}
+    for k, v in data.items():
+        if isinstance(v, str) and v.lower() in ("true", "false"):
+            coerced[k] = v.lower() == "true"
+        else:
+            coerced[k] = v
+    return coerced
 
 
 if _pydantic_major == 2:
     from pydantic import model_validator
 
     class _EngineConfig(BaseModel):
+        """Engine configuration with typed defaults and bool coercion."""
+
         model_config = {"extra": "allow"}
         hide_parameters: bool = True
 
@@ -72,6 +71,8 @@ else:
     from pydantic import root_validator
 
     class _EngineConfig(BaseModel):  # type: ignore[no-redef]
+        """Engine configuration with typed defaults and bool coercion."""
+
         hide_parameters: bool = True
 
         class Config:

--- a/fastapi_sqla/sqla.py
+++ b/fastapi_sqla/sqla.py
@@ -50,12 +50,21 @@ def get_envvar_prefix(key: str) -> str:
     return envvar_prefix
 
 
+def _resolve_hide_parameters(lowercase_environ: dict, envvar_prefix: str) -> bool:
+    key = f"{envvar_prefix}hide_parameters"
+    value = lowercase_environ.pop(key, None)
+    if value is None:
+        return True
+    return value.lower() == "true"
+
+
 def new_engine(key: str = _DEFAULT_SESSION_KEY) -> Union[Engine, Connection]:
     envvar_prefix = get_envvar_prefix(key)
     lowercase_environ = {k.lower(): v for k, v in os.environ.items()}
     lowercase_environ.pop(f"{envvar_prefix}warn_20", None)
+    hide_parameters = _resolve_hide_parameters(lowercase_environ, envvar_prefix)
     return engine_from_config(
-        lowercase_environ, prefix=envvar_prefix, hide_parameters=True
+        lowercase_environ, prefix=envvar_prefix, hide_parameters=hide_parameters
     )
 
 

--- a/fastapi_sqla/sqla.py
+++ b/fastapi_sqla/sqla.py
@@ -26,11 +26,6 @@ except ImportError:
     DeclarativeBase = declarative_base()  # type: ignore
 
 try:
-    from pydantic import ConfigDict as _ConfigDict
-except ImportError:
-    _ConfigDict = None  # type: ignore[assignment,misc]
-
-try:
     from sqlmodel import Session as SqlaSession  # type: ignore
 
 except ImportError:
@@ -44,23 +39,13 @@ _REQUEST_SESSION_KEY = "fastapi_sqla_session"
 _session_factories: dict[str, sessionmaker] = {}
 
 
-if _ConfigDict is not None:
+class _EngineConfig(BaseModel):
+    """Engine configuration with typed defaults and bool coercion."""
 
-    class _EngineConfig(BaseModel):
-        """Engine configuration with typed defaults and bool coercion."""
+    hide_parameters: bool = True
 
-        model_config = _ConfigDict(extra="allow")
-        hide_parameters: bool = True
-
-else:
-
-    class _EngineConfig(BaseModel):  # type: ignore[no-redef]
-        """Engine configuration with typed defaults and bool coercion."""
-
-        hide_parameters: bool = True
-
-        class Config:
-            extra = "allow"
+    class Config:
+        extra = "allow"
 
 
 class Base(DeclarativeBase, DeferredReflection):
@@ -90,7 +75,7 @@ def _get_engine_config(
         if k.startswith(envvar_prefix)
     }
     config = _EngineConfig(**overrides)  # type: ignore[arg-type]
-    coerced = config.model_dump() if hasattr(config, "model_dump") else config.dict()
+    coerced = config.dict()
     for param, value in coerced.items():
         lowercase_env[f"{envvar_prefix}{param}"] = value
 

--- a/fastapi_sqla/sqla.py
+++ b/fastapi_sqla/sqla.py
@@ -9,6 +9,7 @@ from fastapi import Depends, Request, Response
 from fastapi.concurrency import contextmanager_in_threadpool
 from fastapi.responses import PlainTextResponse
 from pydantic import BaseModel
+from pydantic import __version__ as pydantic_version
 from sqlalchemy import engine_from_config, text
 from sqlalchemy.engine import Connection, Engine
 from sqlalchemy.ext.declarative import DeferredReflection
@@ -39,13 +40,26 @@ _REQUEST_SESSION_KEY = "fastapi_sqla_session"
 _session_factories: dict[str, sessionmaker] = {}
 
 
-class _EngineConfig(BaseModel):
-    """Engine configuration with typed defaults and bool coercion."""
+_pydantic_major = int(pydantic_version.split(".")[0])
 
-    hide_parameters: bool = True
+if _pydantic_major == 2:
+    from pydantic import ConfigDict
 
-    class Config:
-        extra = "allow"
+    class _EngineConfig(BaseModel):
+        """Engine configuration with typed defaults and bool coercion."""
+
+        model_config = ConfigDict(extra="allow")
+        hide_parameters: bool = True
+
+else:
+
+    class _EngineConfig(BaseModel):  # type: ignore[no-redef]
+        """Engine configuration with typed defaults and bool coercion."""
+
+        hide_parameters: bool = True
+
+        class Config:
+            extra = "allow"
 
 
 class Base(DeclarativeBase, DeferredReflection):
@@ -75,7 +89,7 @@ def _get_engine_config(
         if k.startswith(envvar_prefix)
     }
     config = _EngineConfig(**overrides)  # type: ignore[arg-type]
-    coerced = config.dict()
+    coerced = config.model_dump() if _pydantic_major == 2 else config.dict()
     for param, value in coerced.items():
         lowercase_env[f"{envvar_prefix}{param}"] = value
 

--- a/fastapi_sqla/sqla.py
+++ b/fastapi_sqla/sqla.py
@@ -50,21 +50,37 @@ def get_envvar_prefix(key: str) -> str:
     return envvar_prefix
 
 
-def _resolve_hide_parameters(lowercase_environ: dict, envvar_prefix: str) -> bool:
-    key = f"{envvar_prefix}hide_parameters"
-    value = lowercase_environ.pop(key, None)
-    if value is None:
-        return True
-    return value.lower() == "true"
+_ENGINE_DEFAULTS = {
+    "hide_parameters": True,
+}
+
+
+def _apply_engine_defaults(
+    lowercase_environ: dict,
+    envvar_prefix: str,
+    defaults: dict = _ENGINE_DEFAULTS,
+) -> dict:
+    """Resolve opinionated engine defaults from env vars."""
+    result = {}
+    for param, default in defaults.items():
+        env_key = f"{envvar_prefix}{param}"
+        value = lowercase_environ.pop(env_key, None)
+        if value is None:
+            result[param] = default
+        elif isinstance(default, bool):
+            result[param] = value.lower() == "true"
+        else:
+            result[param] = value
+    return result
 
 
 def new_engine(key: str = _DEFAULT_SESSION_KEY) -> Union[Engine, Connection]:
     envvar_prefix = get_envvar_prefix(key)
     lowercase_environ = {k.lower(): v for k, v in os.environ.items()}
     lowercase_environ.pop(f"{envvar_prefix}warn_20", None)
-    hide_parameters = _resolve_hide_parameters(lowercase_environ, envvar_prefix)
+    engine_defaults = _apply_engine_defaults(lowercase_environ, envvar_prefix)
     return engine_from_config(
-        lowercase_environ, prefix=envvar_prefix, hide_parameters=hide_parameters
+        lowercase_environ, prefix=envvar_prefix, **engine_defaults
     )
 
 

--- a/fastapi_sqla/sqla.py
+++ b/fastapi_sqla/sqla.py
@@ -58,16 +58,21 @@ _ENGINE_DEFAULTS = {
 def _get_engine_config(
     envvar_prefix: str,
     defaults: dict = _ENGINE_DEFAULTS,
-) -> dict:
+) -> dict[str, Union[str, bool]]:
     """Build engine config dict with opinionated defaults and type coercion."""
-    lowercase_env = {k.lower(): v for k, v in os.environ.items()}
+    lowercase_env: dict[str, Union[str, bool]] = {
+        k.lower(): v for k, v in os.environ.items()
+    }
     lowercase_env.pop(f"{envvar_prefix}warn_20", None)
     for param, default in defaults.items():
         env_key = f"{envvar_prefix}{param}"
         if env_key not in lowercase_env:
             lowercase_env[env_key] = default
         elif isinstance(default, bool):
-            lowercase_env[env_key] = lowercase_env[env_key].lower() == "true"
+            env_val = lowercase_env[env_key]
+            lowercase_env[env_key] = (
+                isinstance(env_val, str) and env_val.lower() == "true"
+            )
     return lowercase_env
 
 

--- a/fastapi_sqla/sqla.py
+++ b/fastapi_sqla/sqla.py
@@ -54,7 +54,7 @@ def new_engine(key: str = _DEFAULT_SESSION_KEY) -> Union[Engine, Connection]:
     envvar_prefix = get_envvar_prefix(key)
     lowercase_environ = {k.lower(): v for k, v in os.environ.items()}
     lowercase_environ.pop(f"{envvar_prefix}warn_20", None)
-    return engine_from_config(lowercase_environ, prefix=envvar_prefix)
+    return engine_from_config(lowercase_environ, prefix=envvar_prefix, hide_parameters=True)
 
 
 def startup(key: str = _DEFAULT_SESSION_KEY):

--- a/fastapi_sqla/sqla.py
+++ b/fastapi_sqla/sqla.py
@@ -53,9 +53,7 @@ def _coerce_bool_string(value):
 
 
 def _coerce_bool_strings(data):
-    if isinstance(data, dict):
-        return {k: _coerce_bool_string(v) for k, v in data.items()}
-    return data
+    return {k: _coerce_bool_string(v) for k, v in data.items()}
 
 
 if _pydantic_major == 2:

--- a/fastapi_sqla/sqla.py
+++ b/fastapi_sqla/sqla.py
@@ -36,6 +36,9 @@ logger = structlog.get_logger(__name__)
 _DEFAULT_SESSION_KEY = "default"
 _REQUEST_SESSION_KEY = "fastapi_sqla_session"
 _session_factories: dict[str, sessionmaker] = {}
+_ENGINE_DEFAULTS = {
+    "hide_parameters": True,
+}
 
 
 class Base(DeclarativeBase, DeferredReflection):
@@ -48,11 +51,6 @@ def get_envvar_prefix(key: str) -> str:
         envvar_prefix = f"fastapi_sqla__{key}__{envvar_prefix}"
 
     return envvar_prefix
-
-
-_ENGINE_DEFAULTS = {
-    "hide_parameters": True,
-}
 
 
 def _get_engine_config(

--- a/fastapi_sqla/sqla.py
+++ b/fastapi_sqla/sqla.py
@@ -8,6 +8,8 @@ import structlog
 from fastapi import Depends, Request, Response
 from fastapi.concurrency import contextmanager_in_threadpool
 from fastapi.responses import PlainTextResponse
+from pydantic import BaseModel
+from pydantic import __version__ as pydantic_version
 from sqlalchemy import engine_from_config, text
 from sqlalchemy.engine import Connection, Engine
 from sqlalchemy.ext.declarative import DeferredReflection
@@ -16,6 +18,8 @@ from sqlalchemy.orm.session import sessionmaker
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 from fastapi_sqla import aws_aurora_support, aws_rds_iam_support
+
+_pydantic_major = int(pydantic_version.split(".")[0])
 
 try:
     from sqlalchemy.orm import DeclarativeBase
@@ -36,9 +40,49 @@ logger = structlog.get_logger(__name__)
 _DEFAULT_SESSION_KEY = "default"
 _REQUEST_SESSION_KEY = "fastapi_sqla_session"
 _session_factories: dict[str, sessionmaker] = {}
-_ENGINE_DEFAULTS = {
-    "hide_parameters": True,
-}
+
+
+def _coerce_bool_string(value):
+    if isinstance(value, str):
+        lowered = value.lower()
+        if lowered == "true":
+            return True
+        if lowered == "false":
+            return False
+    return value
+
+
+def _coerce_bool_strings(data):
+    if isinstance(data, dict):
+        return {k: _coerce_bool_string(v) for k, v in data.items()}
+    return data
+
+
+if _pydantic_major == 2:
+    from pydantic import model_validator
+
+    class _EngineConfig(BaseModel):
+        model_config = {"extra": "allow"}
+        hide_parameters: bool = True
+
+        @model_validator(mode="before")
+        @classmethod
+        def coerce_booleans(cls, data):
+            return _coerce_bool_strings(data)
+
+else:
+    from pydantic import root_validator
+
+    class _EngineConfig(BaseModel):  # type: ignore[no-redef]
+        hide_parameters: bool = True
+
+        class Config:
+            extra = "allow"
+
+        @root_validator(pre=True)
+        @classmethod
+        def coerce_booleans(cls, values):
+            return _coerce_bool_strings(values)
 
 
 class Base(DeclarativeBase, DeferredReflection):
@@ -55,22 +99,23 @@ def get_envvar_prefix(key: str) -> str:
 
 def _get_engine_config(
     envvar_prefix: str,
-    defaults: dict = _ENGINE_DEFAULTS,
 ) -> dict[str, Union[str, bool]]:
     """Build engine config dict with opinionated defaults and type coercion."""
     lowercase_env: dict[str, Union[str, bool]] = {
         k.lower(): v for k, v in os.environ.items()
     }
     lowercase_env.pop(f"{envvar_prefix}warn_20", None)
-    for param, default in defaults.items():
-        env_key = f"{envvar_prefix}{param}"
-        if env_key not in lowercase_env:
-            lowercase_env[env_key] = default
-        elif isinstance(default, bool):
-            env_val = lowercase_env[env_key]
-            lowercase_env[env_key] = (
-                isinstance(env_val, str) and env_val.lower() == "true"
-            )
+
+    overrides = {
+        k[len(envvar_prefix):]: v
+        for k, v in lowercase_env.items()
+        if k.startswith(envvar_prefix)
+    }
+    config = _EngineConfig(**overrides)
+    coerced = config.model_dump() if _pydantic_major == 2 else config.dict()
+    for param, value in coerced.items():
+        lowercase_env[f"{envvar_prefix}{param}"] = value
+
     return lowercase_env
 
 

--- a/fastapi_sqla/sqla.py
+++ b/fastapi_sqla/sqla.py
@@ -55,33 +55,26 @@ _ENGINE_DEFAULTS = {
 }
 
 
-def _apply_engine_defaults(
-    lowercase_environ: dict,
+def _get_engine_config(
     envvar_prefix: str,
     defaults: dict = _ENGINE_DEFAULTS,
 ) -> dict:
-    """Resolve opinionated engine defaults from env vars."""
-    result = {}
+    """Build engine config dict with opinionated defaults and type coercion."""
+    lowercase_env = {k.lower(): v for k, v in os.environ.items()}
+    lowercase_env.pop(f"{envvar_prefix}warn_20", None)
     for param, default in defaults.items():
         env_key = f"{envvar_prefix}{param}"
-        value = lowercase_environ.pop(env_key, None)
-        if value is None:
-            result[param] = default
+        if env_key not in lowercase_env:
+            lowercase_env[env_key] = default
         elif isinstance(default, bool):
-            result[param] = value.lower() == "true"
-        else:
-            result[param] = value
-    return result
+            lowercase_env[env_key] = lowercase_env[env_key].lower() == "true"
+    return lowercase_env
 
 
 def new_engine(key: str = _DEFAULT_SESSION_KEY) -> Union[Engine, Connection]:
     envvar_prefix = get_envvar_prefix(key)
-    lowercase_environ = {k.lower(): v for k, v in os.environ.items()}
-    lowercase_environ.pop(f"{envvar_prefix}warn_20", None)
-    engine_defaults = _apply_engine_defaults(lowercase_environ, envvar_prefix)
-    return engine_from_config(
-        lowercase_environ, prefix=envvar_prefix, **engine_defaults
-    )
+    config = _get_engine_config(envvar_prefix)
+    return engine_from_config(config, prefix=envvar_prefix)
 
 
 def startup(key: str = _DEFAULT_SESSION_KEY):

--- a/fastapi_sqla/sqla.py
+++ b/fastapi_sqla/sqla.py
@@ -77,7 +77,7 @@ else:
         class Config:
             extra = "allow"
 
-        @root_validator(pre=True)
+        @root_validator(pre=True, allow_reuse=True)
         def coerce_booleans(cls, values):  # noqa: N805
             return _coerce_bool_strings(values)
 

--- a/fastapi_sqla/sqla.py
+++ b/fastapi_sqla/sqla.py
@@ -80,8 +80,7 @@ else:
             extra = "allow"
 
         @root_validator(pre=True)
-        @classmethod
-        def coerce_booleans(cls, values):
+        def coerce_booleans(cls, values):  # noqa: N805
             return _coerce_bool_strings(values)
 
 
@@ -111,7 +110,7 @@ def _get_engine_config(
         for k, v in lowercase_env.items()
         if k.startswith(envvar_prefix)
     }
-    config = _EngineConfig(**overrides)
+    config = _EngineConfig(**overrides)  # type: ignore[arg-type]
     coerced = config.model_dump() if _pydantic_major == 2 else config.dict()
     for param, value in coerced.items():
         lowercase_env[f"{envvar_prefix}{param}"] = value

--- a/fastapi_sqla/sqla.py
+++ b/fastapi_sqla/sqla.py
@@ -54,7 +54,9 @@ def new_engine(key: str = _DEFAULT_SESSION_KEY) -> Union[Engine, Connection]:
     envvar_prefix = get_envvar_prefix(key)
     lowercase_environ = {k.lower(): v for k, v in os.environ.items()}
     lowercase_environ.pop(f"{envvar_prefix}warn_20", None)
-    return engine_from_config(lowercase_environ, prefix=envvar_prefix, hide_parameters=True)
+    return engine_from_config(
+        lowercase_environ, prefix=envvar_prefix, hide_parameters=True
+    )
 
 
 def startup(key: str = _DEFAULT_SESSION_KEY):

--- a/tests/test_sqla_startup.py
+++ b/tests/test_sqla_startup.py
@@ -195,18 +195,16 @@ async def test_fastapi_integration():
 @mark.parametrize(
     "env_value, expected",
     [
+        ("true", True),
+        ("false", False),
         ("debug", "debug"),
-        (None, "info"),
     ],
 )
-def test_get_engine_config_non_bool_default(monkeypatch, env_value, expected):
+def test_get_engine_config_coerces_bool_strings(monkeypatch, env_value, expected):
     from fastapi_sqla.sqla import _get_engine_config
 
-    if env_value is not None:
-        monkeypatch.setenv("sqlalchemy_echo", env_value)
-    else:
-        monkeypatch.delenv("sqlalchemy_echo", raising=False)
-    config = _get_engine_config("sqlalchemy_", defaults={"echo": "info"})
+    monkeypatch.setenv("sqlalchemy_echo", env_value)
+    config = _get_engine_config("sqlalchemy_")
 
     assert config["sqlalchemy_echo"] == expected
 

--- a/tests/test_sqla_startup.py
+++ b/tests/test_sqla_startup.py
@@ -209,20 +209,12 @@ def test_get_engine_config_coerces_bool_strings(monkeypatch, env_value, expected
     assert config["sqlalchemy_echo"] == expected
 
 
-@mark.parametrize(
-    "value, expected",
-    [
-        ("true", True),
-        ("false", False),
-        ("debug", "debug"),
-        (True, True),
-        (42, 42),
-    ],
-)
-def test_coerce_bool_string(value, expected):
-    from fastapi_sqla.sqla import _coerce_bool_string
+def test_coerce_bool_strings():
+    from fastapi_sqla.sqla import _coerce_bool_strings
 
-    assert _coerce_bool_string(value) == expected
+    assert _coerce_bool_strings(
+        {"a": "true", "b": "false", "c": "debug", "d": True, "e": 42}
+    ) == {"a": True, "b": False, "c": "debug", "d": True, "e": 42}
 
 
 @mark.parametrize(

--- a/tests/test_sqla_startup.py
+++ b/tests/test_sqla_startup.py
@@ -192,6 +192,16 @@ async def test_fastapi_integration():
     assert res.json() == 1
 
 
+def test_apply_engine_defaults_non_bool():
+    from fastapi_sqla.sqla import _apply_engine_defaults
+
+    environ = {"sqlalchemy_echo": "debug"}
+    result = _apply_engine_defaults(environ, "sqlalchemy_", {"echo": "info"})
+
+    assert result == {"echo": "debug"}
+    assert "sqlalchemy_echo" not in environ
+
+
 def test_new_engine_hides_parameters_by_default():
     from fastapi_sqla.sqla import new_engine
 

--- a/tests/test_sqla_startup.py
+++ b/tests/test_sqla_startup.py
@@ -227,7 +227,9 @@ async def test_new_async_engine_hide_parameters_can_be_disabled(
 ):
     from fastapi_sqla.async_sqla import new_async_engine
 
-    monkeypatch.setenv("sqlalchemy_hide_parameters", "false")
+    monkeypatch.setenv(
+        f"fastapi_sqla__{async_session_key}__sqlalchemy_hide_parameters", "false"
+    )
 
     engine_or_conn = new_async_engine(async_session_key)
 

--- a/tests/test_sqla_startup.py
+++ b/tests/test_sqla_startup.py
@@ -192,7 +192,7 @@ async def test_fastapi_integration():
     assert res.json() == 1
 
 
-def test_new_engine_hides_parameters():
+def test_new_engine_hides_parameters_by_default():
     from fastapi_sqla.sqla import new_engine
 
     engine_or_conn = new_engine()
@@ -200,11 +200,35 @@ def test_new_engine_hides_parameters():
     assert engine_or_conn.engine.hide_parameters is True
 
 
+def test_new_engine_hide_parameters_can_be_disabled(monkeypatch):
+    from fastapi_sqla.sqla import new_engine
+
+    monkeypatch.setenv("sqlalchemy_hide_parameters", "false")
+
+    engine_or_conn = new_engine()
+
+    assert engine_or_conn.engine.hide_parameters is False
+
+
 @mark.require_asyncpg
 @mark.sqlalchemy("1.4")
-async def test_new_async_engine_hides_parameters(async_session_key):
+async def test_new_async_engine_hides_parameters_by_default(async_session_key):
     from fastapi_sqla.async_sqla import new_async_engine
 
     engine_or_conn = new_async_engine(async_session_key)
 
     assert engine_or_conn.sync_engine.hide_parameters is True
+
+
+@mark.require_asyncpg
+@mark.sqlalchemy("1.4")
+async def test_new_async_engine_hide_parameters_can_be_disabled(
+    monkeypatch, async_session_key
+):
+    from fastapi_sqla.async_sqla import new_async_engine
+
+    monkeypatch.setenv("sqlalchemy_hide_parameters", "false")
+
+    engine_or_conn = new_async_engine(async_session_key)
+
+    assert engine_or_conn.sync_engine.hide_parameters is False

--- a/tests/test_sqla_startup.py
+++ b/tests/test_sqla_startup.py
@@ -190,3 +190,21 @@ async def test_fastapi_integration():
         res = await client.get("/one")
 
     assert res.json() == 1
+
+
+def test_new_engine_hides_parameters():
+    from fastapi_sqla.sqla import new_engine
+
+    engine_or_conn = new_engine()
+
+    assert engine_or_conn.engine.hide_parameters is True
+
+
+@mark.require_asyncpg
+@mark.sqlalchemy("1.4")
+async def test_new_async_engine_hides_parameters(async_session_key):
+    from fastapi_sqla.async_sqla import new_async_engine
+
+    engine_or_conn = new_async_engine(async_session_key)
+
+    assert engine_or_conn.sync_engine.hide_parameters is True

--- a/tests/test_sqla_startup.py
+++ b/tests/test_sqla_startup.py
@@ -192,50 +192,50 @@ async def test_fastapi_integration():
     assert res.json() == 1
 
 
-@mark.parametrize(
-    "env_value, expected",
-    [
-        (None, True),
-        ("false", False),
-    ],
-)
-def test_new_engine_hide_parameters(monkeypatch, env_value, expected):
+def test_new_engine_hide_parameters_default(monkeypatch):
     from fastapi_sqla.sqla import new_engine
 
-    if env_value is not None:
-        monkeypatch.setenv("sqlalchemy_hide_parameters", env_value)
-    else:
-        monkeypatch.delenv("sqlalchemy_hide_parameters", raising=False)
+    monkeypatch.delenv("sqlalchemy_hide_parameters", raising=False)
 
     engine_or_conn = new_engine()
 
-    assert engine_or_conn.engine.hide_parameters is expected
+    assert engine_or_conn.engine.hide_parameters is True
+
+
+def test_new_engine_hide_parameters_opt_out(monkeypatch):
+    from fastapi_sqla.sqla import new_engine
+
+    monkeypatch.setenv("sqlalchemy_hide_parameters", "false")
+
+    engine_or_conn = new_engine()
+
+    assert engine_or_conn.engine.hide_parameters is False
 
 
 @mark.require_asyncpg
 @mark.sqlalchemy("1.4")
-@mark.parametrize(
-    "env_value, expected",
-    [
-        (None, True),
-        ("false", False),
-    ],
-)
-async def test_new_async_engine_hide_parameters(
-    monkeypatch, async_session_key, env_value, expected
-):
+async def test_new_async_engine_hide_parameters_default(monkeypatch, async_session_key):
     from fastapi_sqla.async_sqla import new_async_engine
 
-    if env_value is not None:
-        monkeypatch.setenv(
-            f"fastapi_sqla__{async_session_key}__sqlalchemy_hide_parameters", env_value
-        )
-    else:
-        monkeypatch.delenv(
-            f"fastapi_sqla__{async_session_key}__sqlalchemy_hide_parameters",
-            raising=False,
-        )
+    monkeypatch.delenv(
+        f"fastapi_sqla__{async_session_key}__sqlalchemy_hide_parameters",
+        raising=False,
+    )
 
     engine_or_conn = new_async_engine(async_session_key)
 
-    assert engine_or_conn.sync_engine.hide_parameters is expected
+    assert engine_or_conn.sync_engine.hide_parameters is True
+
+
+@mark.require_asyncpg
+@mark.sqlalchemy("1.4")
+async def test_new_async_engine_hide_parameters_opt_out(monkeypatch, async_session_key):
+    from fastapi_sqla.async_sqla import new_async_engine
+
+    monkeypatch.setenv(
+        f"fastapi_sqla__{async_session_key}__sqlalchemy_hide_parameters", "false"
+    )
+
+    engine_or_conn = new_async_engine(async_session_key)
+
+    assert engine_or_conn.sync_engine.hide_parameters is False

--- a/tests/test_sqla_startup.py
+++ b/tests/test_sqla_startup.py
@@ -233,25 +233,28 @@ def test_new_engine_hide_parameters(monkeypatch, env_value, expected):
 
 @mark.require_asyncpg
 @mark.sqlalchemy("1.4")
-async def test_new_async_engine_hides_parameters_by_default(async_session_key):
-    from fastapi_sqla.async_sqla import new_async_engine
-
-    engine_or_conn = new_async_engine(async_session_key)
-
-    assert engine_or_conn.sync_engine.hide_parameters is True
-
-
-@mark.require_asyncpg
-@mark.sqlalchemy("1.4")
-async def test_new_async_engine_hide_parameters_can_be_disabled(
-    monkeypatch, async_session_key
+@mark.parametrize(
+    "env_value, expected",
+    [
+        (None, True),
+        ("false", False),
+    ],
+)
+async def test_new_async_engine_hide_parameters(
+    monkeypatch, async_session_key, env_value, expected
 ):
     from fastapi_sqla.async_sqla import new_async_engine
 
-    monkeypatch.setenv(
-        f"fastapi_sqla__{async_session_key}__sqlalchemy_hide_parameters", "false"
-    )
+    if env_value is not None:
+        monkeypatch.setenv(
+            f"fastapi_sqla__{async_session_key}__sqlalchemy_hide_parameters", env_value
+        )
+    else:
+        monkeypatch.delenv(
+            f"fastapi_sqla__{async_session_key}__sqlalchemy_hide_parameters",
+            raising=False,
+        )
 
     engine_or_conn = new_async_engine(async_session_key)
 
-    assert engine_or_conn.sync_engine.hide_parameters is False
+    assert engine_or_conn.sync_engine.hide_parameters is expected

--- a/tests/test_sqla_startup.py
+++ b/tests/test_sqla_startup.py
@@ -192,40 +192,43 @@ async def test_fastapi_integration():
     assert res.json() == 1
 
 
-def test_get_engine_config_non_bool_default(monkeypatch):
+@mark.parametrize(
+    "env_value, expected",
+    [
+        ("debug", "debug"),
+        (None, "info"),
+    ],
+)
+def test_get_engine_config_non_bool_default(monkeypatch, env_value, expected):
     from fastapi_sqla.sqla import _get_engine_config
 
-    monkeypatch.setenv("sqlalchemy_echo", "debug")
+    if env_value is not None:
+        monkeypatch.setenv("sqlalchemy_echo", env_value)
+    else:
+        monkeypatch.delenv("sqlalchemy_echo", raising=False)
     config = _get_engine_config("sqlalchemy_", defaults={"echo": "info"})
 
-    assert config["sqlalchemy_echo"] == "debug"
+    assert config["sqlalchemy_echo"] == expected
 
 
-def test_get_engine_config_non_bool_default_not_set(monkeypatch):
-    from fastapi_sqla.sqla import _get_engine_config
-
-    monkeypatch.delenv("sqlalchemy_echo", raising=False)
-    config = _get_engine_config("sqlalchemy_", defaults={"echo": "info"})
-
-    assert config["sqlalchemy_echo"] == "info"
-
-
-def test_new_engine_hides_parameters_by_default():
+@mark.parametrize(
+    "env_value, expected",
+    [
+        (None, True),
+        ("false", False),
+    ],
+)
+def test_new_engine_hide_parameters(monkeypatch, env_value, expected):
     from fastapi_sqla.sqla import new_engine
+
+    if env_value is not None:
+        monkeypatch.setenv("sqlalchemy_hide_parameters", env_value)
+    else:
+        monkeypatch.delenv("sqlalchemy_hide_parameters", raising=False)
 
     engine_or_conn = new_engine()
 
-    assert engine_or_conn.engine.hide_parameters is True
-
-
-def test_new_engine_hide_parameters_can_be_disabled(monkeypatch):
-    from fastapi_sqla.sqla import new_engine
-
-    monkeypatch.setenv("sqlalchemy_hide_parameters", "false")
-
-    engine_or_conn = new_engine()
-
-    assert engine_or_conn.engine.hide_parameters is False
+    assert engine_or_conn.engine.hide_parameters is expected
 
 
 @mark.require_asyncpg

--- a/tests/test_sqla_startup.py
+++ b/tests/test_sqla_startup.py
@@ -210,6 +210,22 @@ def test_get_engine_config_coerces_bool_strings(monkeypatch, env_value, expected
 
 
 @mark.parametrize(
+    "value, expected",
+    [
+        ("true", True),
+        ("false", False),
+        ("debug", "debug"),
+        (True, True),
+        (42, 42),
+    ],
+)
+def test_coerce_bool_string(value, expected):
+    from fastapi_sqla.sqla import _coerce_bool_string
+
+    assert _coerce_bool_string(value) == expected
+
+
+@mark.parametrize(
     "env_value, expected",
     [
         (None, True),

--- a/tests/test_sqla_startup.py
+++ b/tests/test_sqla_startup.py
@@ -195,31 +195,6 @@ async def test_fastapi_integration():
 @mark.parametrize(
     "env_value, expected",
     [
-        ("true", True),
-        ("false", False),
-        ("debug", "debug"),
-    ],
-)
-def test_get_engine_config_coerces_bool_strings(monkeypatch, env_value, expected):
-    from fastapi_sqla.sqla import _get_engine_config
-
-    monkeypatch.setenv("sqlalchemy_echo", env_value)
-    config = _get_engine_config("sqlalchemy_")
-
-    assert config["sqlalchemy_echo"] == expected
-
-
-def test_coerce_bool_strings():
-    from fastapi_sqla.sqla import _coerce_bool_strings
-
-    assert _coerce_bool_strings(
-        {"a": "true", "b": "false", "c": "debug", "d": True, "e": 42}
-    ) == {"a": True, "b": False, "c": "debug", "d": True, "e": 42}
-
-
-@mark.parametrize(
-    "env_value, expected",
-    [
         (None, True),
         ("false", False),
     ],

--- a/tests/test_sqla_startup.py
+++ b/tests/test_sqla_startup.py
@@ -192,14 +192,22 @@ async def test_fastapi_integration():
     assert res.json() == 1
 
 
-def test_apply_engine_defaults_non_bool():
-    from fastapi_sqla.sqla import _apply_engine_defaults
+def test_get_engine_config_non_bool_default(monkeypatch):
+    from fastapi_sqla.sqla import _get_engine_config
 
-    environ = {"sqlalchemy_echo": "debug"}
-    result = _apply_engine_defaults(environ, "sqlalchemy_", {"echo": "info"})
+    monkeypatch.setenv("sqlalchemy_echo", "debug")
+    config = _get_engine_config("sqlalchemy_", defaults={"echo": "info"})
 
-    assert result == {"echo": "debug"}
-    assert "sqlalchemy_echo" not in environ
+    assert config["sqlalchemy_echo"] == "debug"
+
+
+def test_get_engine_config_non_bool_default_not_set(monkeypatch):
+    from fastapi_sqla.sqla import _get_engine_config
+
+    monkeypatch.delenv("sqlalchemy_echo", raising=False)
+    config = _get_engine_config("sqlalchemy_", defaults={"echo": "info"})
+
+    assert config["sqlalchemy_echo"] == "info"
 
 
 def test_new_engine_hides_parameters_by_default():


### PR DESCRIPTION
## Problem
- when postgres throws an error, some services will log the params from the query which [gets logged in datadog](https://app.datadoghq.com/logs?query=service%3A%28engage-app%20OR%20engage-engage-to-pinpoint-worker%20OR%20engage-pull-pinpoint-events-worker%20OR%20engage-user-events-worker%20OR%20engage-job-scheduled-messages-dispatcher%20OR%20engage-load-source-identities-worker%29%20status%3Aerror%20IntegrityError&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&event=AwAAAZzN3q1ODKAU9QAAABhBWnpOM3JJTEFBQmhMckhVWkpxTkN3QXUAAAAkMTE5Y2NlMTUtZDQxOC00OGU4LWI1NGUtMjQzYzcyODAwZmFiAAnzVg&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=time%2Casc&viz=stream&from_ts=1772976953588&to_ts=1774272953588&live=true)
- [another example of Scribe logging PHI/PII](https://app.datadoghq.com/logs?query=IntegrityError&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&event=AwAAAZ0mFIIuh1J2rgAAABhBWjBtRklxYUFBQ29ISWg5VHA5bjZ3QVUAAAAkZjE5ZDI2MTQtOGE2OC00NjMwLTkyMWEtMmEyYjJkNGFiNjZiAAAaug&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=time%2Cdesc&viz=stream&from_ts=1772976953588&to_ts=1774272953588&live=true)

## Solution
- to prevent PHI/PII from getting logged in datadog, we should enable `hide_parameters` across all services that are using postgres
- we have enabled this in engage already, which results in the sql params being redacted when there is an error: [see example log with this param as true](https://app.datadoghq.com/logs?query=service%3A%28engage-app%20OR%20engage-engage-to-pinpoint-worker%20OR%20engage-pull-pinpoint-events-worker%20OR%20engage-user-events-worker%20OR%20engage-job-scheduled-messages-dispatcher%20OR%20engage-load-source-identities-worker%29%20status%3Aerror%20IntegrityError&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&event=AwAAAZ0arYT5VZGajgAAABhBWjBhclpJU0FBQ21pUDVuS0JycEJnRDQAAAAkMDE5ZDFhYmMtNmVkMC00NjNkLWFhOTctZjk5ODg1NDkwMTNmAApCzw&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=time%2Cdesc&viz=stream&from_ts=1772976953588&to_ts=1774272953588&live=true)

Changes:                                                                                                                                                                
  - Added _EngineConfig pydantic model with hide_parameters: bool = True default and v1/v2 pydantic branching
  - Extracted shared _get_engine_config() used by both sync and async engines                                                                                                  
  - Added parametrized tests for sync and async engines                               
  - Documented in README how to opt out

## Related
- SQL docs on enabling this with example: https://docs.sqlalchemy.org/en/21/core/engines.html#hiding-parameters
- https://github.com/dialoguemd/charts/pull/757#issuecomment-4112691741
- good related thread: https://dialoguemd.slack.com/archives/C06P5H4NRBM/p1774642813877189

<!-- Relevant: Jira ticket, related PRs, TDs in notion -->

<!-- * #123 -->
<!-- * dialoguemd/scribe#1234  -->
<!-- * [Tech Design](https://www.notion.so/godialogue/854cc91d3e6945dba9be01b9b1f34f8f) -->

* [DIA-86641]

## Validation

Testing in timekeeper
<img width="487" height="77" alt="Screenshot 2026-03-24 at 1 32 53 PM" src="https://github.com/user-attachments/assets/4bcfa5a3-9e84-43f6-ad56-c65bcc6aaf52" />

```
poetry add git+https://github.com/dialoguemd/fastapi-sqla.git#feat/hide-sql-params-DIA-86641
```

```
poetry run python -c "import os; os.environ['SQLALCHEMY_URL'] = 'sqlite:///test.db'; from fastapi_sqla.sqla import new_engine; e = new_engine(); print('hide_parameters:', e.engine.hide_parameters)"
```

- https://github.com/dialoguemd/timekeeper/pull/1697


<!-- How this PR was validated and why it is safe to merge -->

<!-- 📋 Checklist:
1. Title follows [Commit Convention] and [Code Review guidelines]
   - example: feat(lang): add German language - DIA-12345
2. Relevant labels set
3. Draft PR for WIP
4. Validation notes added
5. Requested from and notified to a team

[Commit Convention]: https://www.notion.so/godialogue/Commit-Convention-84fd9a4c149e48c998d760f1c9176df0
[Code Review guidelines]: https://www.notion.so/godialogue/Code-Review-c5f3fcd185ca49aca73ade497c398fe9  -->


[DIA-86641]: https://dialoguemd.atlassian.net/browse/DIA-86641?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ