### PR TITLE
chore: pre-format for ruff 0.16 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ export fastapi_sqla__read_only__sqlalchemy_hide_parameters=false
 import fastapi_sqla
 from fastapi import FastAPI
 
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     await fastapi_sqla.startup()
@@ -255,6 +256,7 @@ AsyncReadOnlySession = Annotated[
     SqlaAsyncSession, Depends(AsyncSessionDependency(key="read_only"))
 ]
 
+
 @router.get("/example")
 def example(session: ReadOnlySession):
     return session.execute("SELECT now()").scalar()
@@ -266,6 +268,7 @@ async def async_example(session: AsyncReadOnlySession):
 
 
 # Alternative
+
 
 @router.get("/example/alt")
 def example_alt(session: SqlaSession = Depends(SessionDependency(key="read_only"))):
@@ -303,13 +306,16 @@ def run_bg():
     with open_session() as session:
         session.execute("SELECT now()").scalar()
 
+
 def run_bg_with_key():
     with open_session(key="read_only") as session:
         session.execute("SELECT now()").scalar()
 
+
 async def run_async_bg():
     async with open_async_session() as session:
         await session.scalar("SELECT now()")
+
 
 async def run_async_bg_with_key():
     async with open_async_session(key="read_only") as session:
@@ -505,7 +511,9 @@ async def query_count(session: AsyncSession) -> int:
     return result.scalar()
 
 
-CustomPaginate = AsyncPagination(min_page_size=5, max_page_size=500, query_count=query_count)
+CustomPaginate = AsyncPagination(
+    min_page_size=5, max_page_size=500, query_count=query_count
+)
 
 
 @router.get("/users", response_model=Page[UserModel])
@@ -554,9 +562,11 @@ AsyncReadOnlyPaginate = Annotated[
     AsyncPaginateSignature, Depends(AsyncPagination(session_key="read_only"))
 ]
 
+
 @router.get("/users", response_model=Page[UserModel])
 def all_users(paginate: ReadOnlyPaginate):
     return paginate(select(User))
+
 
 @router.get("/async_users", response_model=Page[UserModel])
 async def async_all_users(paginate: AsyncReadOnlyPaginate):
@@ -565,13 +575,13 @@ async def async_all_users(paginate: AsyncReadOnlyPaginate):
 
 # Alternative
 
+
 @router.get("/users/alt", response_model=Page[UserModel])
 def all_users_alt(
-    paginate: PaginateSignature = Depends(
-        Pagination(session_key="read_only")
-    ),
+    paginate: PaginateSignature = Depends(Pagination(session_key="read_only")),
 ):
     return paginate(select(User))
+
 
 @router.get("/async_users/alt", response_model=Page[UserModel])
 async def async_all_users_alt(
@@ -587,34 +597,35 @@ async def async_all_users_alt(
 If your project uses [SQLModel], then `Session` dependency is an SQLModel session::
 
 ```python
-    from http import HTTPStatus
+from http import HTTPStatus
 
-    from fastapi import FastAPI, HTTPException
-    from fastapi_sqla import Item, Page, Paginate, Session, setup
-    from sqlmodel import Field, SQLModel, select
-
-    class Hero(SQLModel, table=True):
-        id: int | None = Field(default=None, primary_key=True)
-        name: str
-        secret_name: str
-        age: int | None = None
+from fastapi import FastAPI, HTTPException
+from fastapi_sqla import Item, Page, Paginate, Session, setup
+from sqlmodel import Field, SQLModel, select
 
 
-    app = FastAPI()
-    setup(app)
+class Hero(SQLModel, table=True):
+    id: int | None = Field(default=None, primary_key=True)
+    name: str
+    secret_name: str
+    age: int | None = None
 
-    @app.get("/heros", response_model=Page[Hero])
-    def list_hero(paginate: Paginate) -> Page[Hero]:
-        return paginate(select(Hero))
+
+app = FastAPI()
+setup(app)
 
 
-    @app.get("/heros/{hero_id}", response_model=Item[Hero])
-    def get_hero(hero_id: int, session: Session) -> Item[Hero]:
-        hero = session.get(Hero, hero_id)
-        if hero is None:
-            raise HTTPException(HTTPStatus.NOT_FOUND)
-        return {"data": hero}
+@app.get("/heros", response_model=Page[Hero])
+def list_hero(paginate: Paginate) -> Page[Hero]:
+    return paginate(select(Hero))
 
+
+@app.get("/heros/{hero_id}", response_model=Item[Hero])
+def get_hero(hero_id: int, session: Session) -> Item[Hero]:
+    hero = session.get(Hero, hero_id)
+    if hero is None:
+        raise HTTPException(HTTPStatus.NOT_FOUND)
+    return {"data": hero}
 ```
 
 # Pytest fixtures
@@ -697,6 +708,7 @@ from pytest import fixture
 @fixture
 def patient(session):
     from er.sqla import Patient
+
     patient = Patient(first_name="Bob", last_name="David")
     session.add(patient)
     session.commit()
@@ -706,6 +718,7 @@ def patient(session):
 @fixture
 async def doctor(async_session):
     from er.sqla import Doctor
+
     doctor = Doctor(name="who")
     async_session.add(doctor)
     await async_session.commit()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,6 +122,7 @@ ignore = [
     "PLR0912", # Disable max number of branches
     "PLR0913", # Disable max number of args
     "PLR0915", # Disable max number of statements
+    "PLR0917", # Disable max number of positional args
     "PLR2004", # Enable magic values
     "SIM105",  # Allow using try - except - pass
     "TD001",   # Enable FIXMEs


### PR DESCRIPTION
## Problem

The pending ruff 0.16.0 bump (#434) fails CI: markdown formatting reformats `README.md`, and the newly-stabilized `PLR0917` rule flags 4 existing call sites.

## Solution

Pre-apply both fixes so #434 passes once rebased: `ruff format .` at 0.16.0, and ignore `PLR0917` alongside the existing `PLR0913`/`PLR0912`/`PLR0915` ignores.

## Related

* #434

## Validation

`ruff format --check` and `ruff check` at 0.16.0 both pass on this branch; both still pass at the current pinned 0.15.19.
