### PR TITLE
feat!: drop pydantic v1 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ workflows:
           context: code-validator
 
       - test:
-          name: 🧪 test py<<matrix.python_version>> sqlalchemy-<<matrix.sqlalchemy_version >> pydantic-<<matrix.pydantic_version>> <<matrix.asyncpg>> <<matrix.aws_rds_iam>>
+          name: 🧪 test py<<matrix.python_version>> sqlalchemy-<<matrix.sqlalchemy_version >> <<matrix.asyncpg>> <<matrix.aws_rds_iam>>
           context: code-validator
           matrix:
             parameters:
@@ -49,7 +49,6 @@ workflows:
               sqlalchemy_version: ["1.4", "2.0", "2.0-sqlmodel"]
               asyncpg: ["asyncpg", "noasyncpg"]
               aws_rds_iam: ["aws_rds_iam", "noaws_rds_iam"]
-              pydantic_version: ["1", "2"]
 
       - release/release:
           name: 🕊 release
@@ -97,9 +96,6 @@ jobs:
         type: enum
         enum: ["aws_rds_iam", "noaws_rds_iam"]
         description: To run tests with and without asyncpg installed.
-      pydantic_version:
-        type: enum
-        enum: ["1", "2"]
     executor:
       name: python-postgres
       python_version: <<parameters.python_version>>
@@ -111,16 +107,16 @@ jobs:
       - python/install_deps
       - utils/with_cache:
           namespace: tox
-          key: 'python<<parameters.python_version>>-sqlalchemy<<parameters.sqlalchemy_version>>-pydantic<<parameters.pydantic_version>>-<<parameters.asyncpg>>-<<parameters.aws_rds_iam>>-{{ checksum "pyproject.toml" }}-{{ checksum "poetry.lock" }}'
+          key: 'python<<parameters.python_version>>-sqlalchemy<<parameters.sqlalchemy_version>>-<<parameters.asyncpg>>-<<parameters.aws_rds_iam>>-{{ checksum "pyproject.toml" }}-{{ checksum "poetry.lock" }}'
           path: ~/project/.tox
           strict: true
           steps:
             - run:
-                name: "run tox using sqlalchemy <<parameters.sqlalchemy_version>>.* pydantic<<parameters.pydantic_version>> and -<<parameters.asyncpg>> and -<<parameters.aws_rds_iam>>"
+                name: "run tox using sqlalchemy <<parameters.sqlalchemy_version>>.* and -<<parameters.asyncpg>> and -<<parameters.aws_rds_iam>>"
                 command: |
-                  poetry run tox -e sqlalchemy<<parameters.sqlalchemy_version>>-pydantic<<parameters.pydantic_version>>-<<parameters.asyncpg>>-<<parameters.aws_rds_iam>>
+                  poetry run tox -e sqlalchemy<<parameters.sqlalchemy_version>>-<<parameters.asyncpg>>-<<parameters.aws_rds_iam>>
       - codecov/upload:
-          flags: python_version<<parameters.python_version>>-sqlalchemy<<parameters.sqlalchemy_version>>-pydantic<<parameters.pydantic_version>>-<<parameters.asyncpg>>-<<parameters.aws_rds_iam>>
+          flags: python_version<<parameters.python_version>>-sqlalchemy<<parameters.sqlalchemy_version>>-<<parameters.asyncpg>>-<<parameters.aws_rds_iam>>
 
 
   publish:

--- a/fastapi_sqla/models.py
+++ b/fastapi_sqla/models.py
@@ -1,15 +1,8 @@
 from typing import Generic, TypeVar
 
 from pydantic import BaseModel, Field
-from pydantic import __version__ as pydantic_version
 
-major, _, _ = (int(v) for v in pydantic_version.split("."))
-is_pydantic2 = major == 2
-if is_pydantic2:
-    GenericModel = BaseModel
-else:
-    from pydantic.generics import GenericModel  # type:ignore
-
+GenericModel = BaseModel
 
 ItemT = TypeVar("ItemT")
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -1797,4 +1797,4 @@ sqlmodel = ["sqlmodel"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.14"
-content-hash = "30fab4e56c351ffeedbe813f31a94edba8f054a9cd135edc54e8b4c532cbe477"
+content-hash = "ab87377157a73e7ffa77b2144dfe078776c6cac1b37cdef53c0dded1a44e4f9e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ classifiers = [
 [tool.poetry.dependencies]
 python = ">=3.10,<3.14"
 fastapi = ">=0.95.1,<0.126"
-pydantic = ">=1,<3"
+pydantic = ">=2,<3"
 sqlalchemy = ">=1.3,<3"
 structlog = ">=20,<27"
 deprecated = ">=1.2,<2"
@@ -174,7 +174,7 @@ skip_covered = true
 [tool.tox]
 legacy_tox_ini = """
 [tox]
-envlist = sqlalchemy{ 1.3, 1.4, 2.0, 2.0-sqlmodel }-{ asyncpg, noasyncpg }-{aws_rds_iam, noaws_rds_iam }-pydantic{ 1, 2 }
+envlist = sqlalchemy{ 1.3, 1.4, 2.0, 2.0-sqlmodel }-{ asyncpg, noasyncpg }-{aws_rds_iam, noaws_rds_iam }
 
 [testenv]
 passenv = CI
@@ -191,7 +191,6 @@ commands_pre =
     sqlmodel-asyncpg-aws_rds_iam: poetry install --extras "sqlmodel asyncpg aws_rds_iam"
     sqlalchemy1.3: pip install sqlalchemy==1.3
     sqlalchemy1.4: pip install sqlalchemy==1.4.52
-    pydantic1: pip install pydantic==1.10.16
 commands =
     poetry run pytest -vv --showlocals --cov . --cov-report xml --cov-report html --junitxml=test-reports/pytest/junit.xml
 """


### PR DESCRIPTION
## Problem

fastapi 0.140 (#388) removed `pydantic.main.IncEx`, breaking every pydantic-v1 test matrix cell with `ImportError: cannot import name 'IncEx' from 'pydantic.main'`. pydantic v1 is long past EOL upstream.

## Solution

Drop pydantic v1 support

## Related

* #388 (unblocked by this once merged and released)

## Validation

N/A